### PR TITLE
mount fails when sudo is unavailable

### DIFF
--- a/deployment/flexvol-installer/kv
+++ b/deployment/flexvol-installer/kv
@@ -24,7 +24,7 @@ log() {
 	echo $* >&1
 }
 ismounted() {
-    count=`sudo ls ${MNTPATH} | wc -l`
+    count=`ls ${MNTPATH} | wc -l`
 	if [ $count -gt 0 ] ; then
 		echo "`date` ismounted | ${MNTPATH} exists" >>$LOG
 		echo "1"


### PR DESCRIPTION
tested and pod was created/deleted successfully with secret mounted
fixes: https://github.com/Azure/kubernetes-keyvault-flexvol/issues/25

I'm not too familiar with flexvolumes yet. But, there is `rm ${MNTPATH}`  and `ls ${MNTPATH}` without sudo farther down in the script. So I'm assuming this is run with root privileges.

Thanks!