### PR TITLE
Feature/support multiple secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,15 @@ secretRef:
 |Name|Required|Description|Default Value|
 |---|---|---|---|
 |usepodidentity|no|specify access mode: service principal or pod identity|"false"|
-|keyvaultname|yes|name of key vault instance|""|
-|keyvaultobjectname|yes|name of key vault object to access|""|
-|keyvaultobjecttype|yes|key vault object type: secret, key, cert|""|
-|keyvaultobjectversion|no|key vault object version, if not provided, will use latest|""|
+|keyvaultname|yes|name of KeyVault instance|""|
+|keyvaultobjectnames|yes|names of KeyVault objects to access|""|
+|keyvaultobjecttypes|yes|types of KeyVault objects: secret, key or cert|""|
+|keyvaultobjectversions|no|versions of KeyVault objects, if not provided, will use latest|""|
 |resourcegroup|yes|name of resource group containing key vault instance|""|
 |subscriptionid|yes|name of subscription containing key vault instance|""|
 |tenantid|yes|name of tenant containing key vault instance|""|
+
+keyvaultobjectnames, keyvaultobjecttypes and keyvaultobjectversions are semi-colon (;) separated.
 
 3. Specify mount path of flexvolume to mount key vault objects
 ```yaml
@@ -119,9 +121,9 @@ spec:
       options:
         usepodidentity: "false"
         keyvaultname: "testkeyvault"
-        keyvaultobjectname: "testsecret"
-        keyvaultobjecttype: secret # OPTIONS: secret, key, cert
-        keyvaultobjectversion: "testversion"
+        keyvaultobjectnames: "testsecret"
+        keyvaultobjecttypes: secret # OPTIONS: secret, key, cert
+        keyvaultobjectversions: "testversion"
         resourcegroup: "testresourcegroup"
         subscriptionid: "testsub"
         tenantid: "testtenant"

--- a/azurekeyvault-flexvolume/Gopkg.lock
+++ b/azurekeyvault-flexvolume/Gopkg.lock
@@ -2,38 +2,66 @@
 
 
 [[projects]]
+  digest = "1:978aa4b8b3218ac2aac482e096ff94d7da15326fe3b35dfa2b6351ef170d8cbb"
   name = "github.com/Azure/azure-sdk-for-go"
-  packages = ["services/keyvault/2016-10-01/keyvault","services/keyvault/mgmt/2016-10-01/keyvault","version"]
+  packages = [
+    "services/keyvault/2016-10-01/keyvault",
+    "services/keyvault/mgmt/2016-10-01/keyvault",
+    "version",
+  ]
+  pruneopts = ""
   revision = "4650843026a7fdec254a8d9cf893693a254edd0b"
   version = "v16.2.1"
 
 [[projects]]
+  digest = "1:0831bf5467f1721a3f1afaf1b3a0474df01f114544dfffcdf017d15ea6b5603f"
   name = "github.com/Azure/go-autorest"
-  packages = ["autorest","autorest/adal","autorest/azure","autorest/date","autorest/to","autorest/validation"]
+  packages = [
+    "autorest",
+    "autorest/adal",
+    "autorest/azure",
+    "autorest/date",
+    "autorest/to",
+    "autorest/validation",
+  ]
+  pruneopts = ""
   revision = "eaa7994b2278094c904d31993d26f56324db3052"
   version = "v10.8.1"
 
 [[projects]]
+  digest = "1:6098222470fe0172157ce9bbef5d2200df4edde17ee649c5d6e48330e4afa4c6"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
+  pruneopts = ""
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:107b233e45174dbab5b1324201d092ea9448e58243ab9f039e4c0f332e121e3a"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = ""
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
+  digest = "1:7f569d906bdd20d906b606415b7d794f798f91a62fcfb6a4daa6d50690fb7a3f"
   name = "github.com/satori/go.uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
   version = "v1.2.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0b5b5c9b977900c51765ae689830ca66b45cbfaa4196a6c3ee9a90e115ef0652"
+  input-imports = [
+    "github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault",
+    "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2016-10-01/keyvault",
+    "github.com/Azure/go-autorest/autorest",
+    "github.com/Azure/go-autorest/autorest/adal",
+    "github.com/Azure/go-autorest/autorest/azure",
+    "github.com/golang/glog",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/azurekeyvault-flexvolume/main.go
+++ b/azurekeyvault-flexvolume/main.go
@@ -250,14 +250,6 @@ func parseConfigs() error {
 	return nil
 }
 
-func getEnv(variable, value string) string {
-	if v := os.Getenv(variable); v != "" {
-		return v
-	}
-
-	return value
-}
-
 func showUsage(message string, args ...interface{}) {
 	flag.PrintDefaults()
 	if message != "" {

--- a/deployment/flexvol-installer/install.sh
+++ b/deployment/flexvol-installer/install.sh
@@ -20,5 +20,5 @@ cp /bin/azurekeyvault-flexvolume ${kv_vol_dir}/azurekeyvault-flexvolume #script
 #https://github.com/kubernetes/kubernetes/issues/17182
 # if we are running on kubernetes cluster as a daemon set we should
 # not exit otherwise, container will restart and goes into crashloop (even if exit code is 0)
-while true; do echo "install done, daemonset sleeping" && sleep 300; done
+while true; do echo "install done, daemonset sleeping" && sleep 60; done
 

--- a/deployment/flexvol-installer/kv
+++ b/deployment/flexvol-installer/kv
@@ -58,6 +58,14 @@ mount() {
 	KEYVAULT_OBJECT_VERSIONS="$(echo "$2"|"$JQ" -r '.keyvaultobjectversions //empty')"
 	ALIAS="$(echo "$2"|"$JQ" -r '.alias //empty')"
 	
+    # backward compatibility (should be deprecated!)
+	if [ -z "${KEYVAULT_OBJECT_NAMES}" ]; then
+		KEYVAULT_OBJECT_NAMES="$(echo "$2"|"$JQ" -r '.keyvaultobjectname //empty')"
+		KEYVAULT_OBJECT_TYPES="$(echo "$2"|"$JQ" -r '.keyvaultobjecttype //empty')"
+		KEYVAULT_OBJECT_VERSIONS="$(echo "$2"|"$JQ" -r '.keyvaultobjectversion //empty')"
+
+	fi
+
 	if [ $(ismounted) -eq 1 ] ; then
 		log "{\"status\": \"Success\"}"
 		exit 0

--- a/deployment/flexvol-installer/kv
+++ b/deployment/flexvol-installer/kv
@@ -3,7 +3,7 @@
 DIR=$(dirname "$(readlink -f "$0")")
 JQ="/usr/bin/jq"
 LOG="/var/log/kv-driver.log"
-VER="0.0.5"
+VER="0.0.6"
 KVFV="${DIR}/azurekeyvault-flexvolume"
 
 usage() {
@@ -48,14 +48,14 @@ mount() {
 	SUBSCRIPTION_ID="$(echo "$2"|"$JQ" -r '.subscriptionid //empty')"
 	TENANT_ID="$(echo "$2"|"$JQ" -r '.tenantid //empty')"
 	KEYVAULT_NAME="$(echo "$2"|"$JQ" -r '.keyvaultname //empty')"
-	KEYVAULT_OBJECT_NAME="$(echo "$2"|"$JQ" -r '.keyvaultobjectname //empty')"
-	KEYVAULT_OBJECT_TYPE="$(echo "$2"|"$JQ" -r '.keyvaultobjecttype //empty')"
+	KEYVAULT_OBJECT_NAMES="$(echo "$2"|"$JQ" -r '.keyvaultobjectnames //empty')"
+	KEYVAULT_OBJECT_TYPES="$(echo "$2"|"$JQ" -r '.keyvaultobjecttypes //empty')"
 	
 	USE_POD_IDENTITY="$(echo "$2"|"$JQ" -r '.usepodidentity //empty')"
 
 	# Optional
 	CLOUD_NAME="$(echo "$2"|"$JQ" -r '.cloudname //empty')"
-	KEYVAULT_OBJECT_VERSION="$(echo "$2"|"$JQ" -r '.keyvaultobjectversion //empty')"
+	KEYVAULT_OBJECT_VERSIONS="$(echo "$2"|"$JQ" -r '.keyvaultobjectversions //empty')"
 	ALIAS="$(echo "$2"|"$JQ" -r '.alias //empty')"
 	
 	if [ $(ismounted) -eq 1 ] ; then
@@ -84,13 +84,13 @@ mount() {
 		exit 1
 	fi
 
-	if [ -z "${KEYVAULT_OBJECT_NAME}" ]; then
-		err "{\"status\": \"Failure\", \"message\": \"validation failed, keyvaultobjectname is empty\"}"
+	if [ -z "${KEYVAULT_OBJECT_NAMES}" ]; then
+		err "{\"status\": \"Failure\", \"message\": \"validation failed, keyvaultobjectnames is empty\"}"
 		exit 1
 	fi
 
-	if [ -z "${KEYVAULT_OBJECT_TYPE}" ]; then
-		err "{\"status\": \"Failure\", \"message\": \"validation failed, keyvaultobjecttype is empty\"}"
+	if [ -z "${KEYVAULT_OBJECT_TYPES}" ]; then
+		err "{\"status\": \"Failure\", \"message\": \"validation failed, keyvaultobjecttypes is empty\"}"
 		exit 1
 	fi
 
@@ -131,8 +131,8 @@ mount() {
 	fi
 	
 
-	echo "`date` EXEC: $KVFV -logtostderr=1 -vaultName=${KEYVAULT_NAME} -vaultObjectName=${KEYVAULT_OBJECT_NAME} -resourceGroup=${RESOURCE_GROUP} -dir=${MNTPATH} -subscriptionId=${SUBSCRIPTION_ID} -cloudName=${CLOUD_NAME} -tenantId=${TENANT_ID} -aADClientSecret=${CLIENTSECRET} -aADClientID=${CLIENTID} -usePodIdentity=${USE_POD_IDENTITY} -podNamespace=${PODNAMESPACE} -podName=${PODNAME} -vaultObjectVersion=${KEYVAULT_OBJECT_VERSION} -vaultObjectType=${KEYVAULT_OBJECT_TYPE}" >> $LOG
-	$KVFV -logtostderr=1 -vaultName=${KEYVAULT_NAME} -vaultObjectName=${KEYVAULT_OBJECT_NAME} -resourceGroup=${RESOURCE_GROUP} -dir=${MNTPATH} -subscriptionId=${SUBSCRIPTION_ID} -cloudName=${CLOUD_NAME} -tenantId=${TENANT_ID} -aADClientSecret=${CLIENTSECRET} -aADClientID=${CLIENTID} -usePodIdentity=${USE_POD_IDENTITY} -podNamespace=${PODNAMESPACE} -podName=${PODNAME} -vaultObjectVersion=${KEYVAULT_OBJECT_VERSION} -vaultObjectType=${KEYVAULT_OBJECT_TYPE} >>$LOG 2>&1
+	echo "`date` EXEC: $KVFV -logtostderr=1 -vaultName=${KEYVAULT_NAME} -vaultObjectNames=${KEYVAULT_OBJECT_NAMES} -resourceGroup=${RESOURCE_GROUP} -dir=${MNTPATH} -subscriptionId=${SUBSCRIPTION_ID} -cloudName=${CLOUD_NAME} -tenantId=${TENANT_ID} -aADClientSecret=${CLIENTSECRET} -aADClientID=${CLIENTID} -usePodIdentity=${USE_POD_IDENTITY} -podNamespace=${PODNAMESPACE} -podName=${PODNAME} -vaultObjectVersions=${KEYVAULT_OBJECT_VERSIONS} -vaultObjectTypes=${KEYVAULT_OBJECT_TYPES}" >> $LOG
+	$KVFV -logtostderr=1 -vaultName=${KEYVAULT_NAME} -vaultObjectNames=${KEYVAULT_OBJECT_NAMES} -resourceGroup=${RESOURCE_GROUP} -dir=${MNTPATH} -subscriptionId=${SUBSCRIPTION_ID} -cloudName=${CLOUD_NAME} -tenantId=${TENANT_ID} -aADClientSecret=${CLIENTSECRET} -aADClientID=${CLIENTID} -usePodIdentity=${USE_POD_IDENTITY} -podNamespace=${PODNAMESPACE} -podName=${PODNAME} -vaultObjectVersions=${KEYVAULT_OBJECT_VERSIONS} -vaultObjectTypes=${KEYVAULT_OBJECT_TYPES} >>$LOG 2>&1
 	
 	if [ $? -ne 0 ] ; then
 		errorLog=`tail -n 1 "${LOG}"`

--- a/deployment/kv-flexvol-installer.yaml
+++ b/deployment/kv-flexvol-installer.yaml
@@ -18,10 +18,8 @@ spec:
     spec:
       tolerations:
       containers:
-        # * if you have used flex before on your cluster, use same directory
-        # set TARGET_DIR env var and mount the same directory to to the container
       - name: flexvol-driver-installer
-        image: "mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.5"
+        image: "idanl/keyvault-flexvolume:v0.0.6"
         imagePullPolicy: Always
         resources:
           requests:
@@ -31,9 +29,8 @@ spec:
             cpu: 50m
             memory: 10Mi
         env:
-        #forces the container not to exit 
-        # to solve for this https://github.com/kubernetes/kubernetes/issues/17182
-        # until it is fixed
+          # if you have used flex before on your cluster, use same directory
+          # set TARGET_DIR env var and mount the same directory to to the container
         - name: TARGET_DIR
           value: "/etc/kubernetes/volumeplugins"
         volumeMounts:
@@ -41,7 +38,10 @@ spec:
           name: volplugins
       volumes:
       - hostPath:
-          path: "/etc/kubernetes/volumeplugins" #Modify this directory if your nodes are using a different one
+          # Modify this directory if your nodes are using a different one
+          # default is "/usr/libexec/kubernetes/kubelet-plugins/volume/exec" 
+          # below is Azure default
+          path: "/etc/kubernetes/volumeplugins" 
         name: volplugins
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/deployment/kv-flexvol-installer.yaml
+++ b/deployment/kv-flexvol-installer.yaml
@@ -19,7 +19,7 @@ spec:
       tolerations:
       containers:
       - name: flexvol-driver-installer
-        image: "idanl/keyvault-flexvolume:v0.0.6"
+        image: "mcr.microsoft.com/k8s/flexvolume/keyvault-flexvolume:v0.0.5"
         imagePullPolicy: Always
         resources:
           requests:

--- a/deployment/nginx-flex-kv-podidentity.yaml
+++ b/deployment/nginx-flex-kv-podidentity.yaml
@@ -18,11 +18,11 @@ spec:
     flexVolume:
       driver: "azure/kv"
       options:
-        usepodidentity: "true" # OPTIONAL, if not provided, will default to "false"
-        keyvaultname: ""
-        keyvaultobjectname: ""
-        keyvaultobjecttype: secret # OPTIONS: secret, key, cert
-        keyvaultobjectversion: "" # OPTIONAL, if not provided, will get latest
-        resourcegroup: ""
-        subscriptionid: ""
-        tenantid: ""
+        usepodidentity: "true"         # [OPTIONAL] if not provided, will default to "false"
+        keyvaultname: ""               # the name of the KeyVault
+        keyvaultobjectnames: ""        # list of KeyVault object names (semi-colon separated)
+        keyvaultobjecttypes: secret    # list of KeyVault object types: secret, key or cert (semi-colon separated)
+        keyvaultobjectversions: ""     # [OPTIONAL] list of KeyVault object versions (semi-colon separated), will get latest if empty
+        resourcegroup: ""              # the resource group of the KeyVault
+        subscriptionid: ""             # the subscription ID of the KeyVault
+        tenantid: ""                   # the tenant ID of the KeyVault

--- a/deployment/nginx-flex-kv.yaml
+++ b/deployment/nginx-flex-kv.yaml
@@ -15,13 +15,13 @@ spec:
     flexVolume:
       driver: "azure/kv"
       secretRef:
-        name: kvcreds
+        name: kvcreds                  # [OPTIONAL] not required if using Pod Identity
       options:
-        usepodidentity: "false" # OPTIONAL, if not provided, will default to "false"
-        keyvaultname: ""
-        keyvaultobjectname: ""
-        keyvaultobjecttype: secret # OPTIONS: secret, key, cert
-        keyvaultobjectversion: "" # OPTIONAL, if not provided, will get latest
-        resourcegroup: ""
-        subscriptionid: ""
-        tenantid: ""
+        usepodidentity: "false"        # [OPTIONAL] if not provided, will default to "false"
+        keyvaultname: ""               # the name of the KeyVault
+        keyvaultobjectnames: ""        # list of KeyVault object names (semi-colon separated)
+        keyvaultobjecttypes: secret    # list of KeyVault object types: secret, key or cert (semi-colon separated)
+        keyvaultobjectversions: ""     # [OPTIONAL] list of KeyVault object versions (semi-colon separated), will get latest if empty
+        resourcegroup: ""              # the resource group of the KeyVault
+        subscriptionid: ""             # the subscription ID of the KeyVault
+        tenantid: ""                   # the tenant ID of the KeyVault


### PR DESCRIPTION
this is a best-effort implementation of multiple secrets, I wanted to do it nicer by allowing the user to create an array of objects but it turns out the `flexVolume` `options` only support strings, so I ended up going with a semi-colon separated list of objects

I don't have access to `mcr.microsoft.com/k8s/flexvolume` so I replaced it with my personal Dockerhub until fixed


fixes this: https://github.com/Azure/kubernetes-keyvault-flexvol/issues/37