### PR TITLE
[WIP] : Refactoring to extract logic from the main func

### DIFF
--- a/azurekeyvault-flexvolume/AUTHORS
+++ b/azurekeyvault-flexvolume/AUTHORS
@@ -1,0 +1,7 @@
+Idan <rita.z.zhang@gmail.com>
+Jacob Sohl <jacobsohl@gmail.com>
+Khaled Henidak(Kal) <khnidk@microsoft.com>
+Paulo Gomes <Paulo.Gomes.uk@gmail.com>
+Rita Zhang <rita.z.zhang@gmail.com>
+Stéphane Erbrech <stephane.erbrech@gmail.com>
+twem <rita.z.zhang@gmail.com>

--- a/azurekeyvault-flexvolume/AUTHORS
+++ b/azurekeyvault-flexvolume/AUTHORS
@@ -4,4 +4,5 @@ Khaled Henidak(Kal) <khnidk@microsoft.com>
 Paulo Gomes <Paulo.Gomes.uk@gmail.com>
 Rita Zhang <rita.z.zhang@gmail.com>
 Stéphane Erbrech <stephane.erbrech@gmail.com>
+Stephane Erbrech <sterbrec@microsoft.com>
 twem <rita.z.zhang@gmail.com>

--- a/azurekeyvault-flexvolume/Gopkg.lock
+++ b/azurekeyvault-flexvolume/Gopkg.lock
@@ -45,6 +45,14 @@
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
+  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = ""
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
   digest = "1:7f569d906bdd20d906b606415b7d794f798f91a62fcfb6a4daa6d50690fb7a3f"
   name = "github.com/satori/go.uuid"
   packages = ["."]
@@ -62,6 +70,7 @@
     "github.com/Azure/go-autorest/autorest/adal",
     "github.com/Azure/go-autorest/autorest/azure",
     "github.com/golang/glog",
+    "github.com/pkg/errors",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/azurekeyvault-flexvolume/Gopkg.lock
+++ b/azurekeyvault-flexvolume/Gopkg.lock
@@ -2,75 +2,44 @@
 
 
 [[projects]]
-  digest = "1:978aa4b8b3218ac2aac482e096ff94d7da15326fe3b35dfa2b6351ef170d8cbb"
   name = "github.com/Azure/azure-sdk-for-go"
-  packages = [
-    "services/keyvault/2016-10-01/keyvault",
-    "services/keyvault/mgmt/2016-10-01/keyvault",
-    "version",
-  ]
-  pruneopts = ""
+  packages = ["services/keyvault/2016-10-01/keyvault","services/keyvault/mgmt/2016-10-01/keyvault","version"]
   revision = "4650843026a7fdec254a8d9cf893693a254edd0b"
   version = "v16.2.1"
 
 [[projects]]
-  digest = "1:0831bf5467f1721a3f1afaf1b3a0474df01f114544dfffcdf017d15ea6b5603f"
   name = "github.com/Azure/go-autorest"
-  packages = [
-    "autorest",
-    "autorest/adal",
-    "autorest/azure",
-    "autorest/date",
-    "autorest/to",
-    "autorest/validation",
-  ]
-  pruneopts = ""
+  packages = ["autorest","autorest/adal","autorest/azure","autorest/date","autorest/to","autorest/validation"]
   revision = "eaa7994b2278094c904d31993d26f56324db3052"
   version = "v10.8.1"
 
 [[projects]]
-  digest = "1:6098222470fe0172157ce9bbef5d2200df4edde17ee649c5d6e48330e4afa4c6"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
-  pruneopts = ""
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:107b233e45174dbab5b1324201d092ea9448e58243ab9f039e4c0f332e121e3a"
   name = "github.com/golang/glog"
   packages = ["."]
-  pruneopts = ""
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
-  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
   name = "github.com/pkg/errors"
   packages = ["."]
-  pruneopts = ""
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:7f569d906bdd20d906b606415b7d794f798f91a62fcfb6a4daa6d50690fb7a3f"
   name = "github.com/satori/go.uuid"
   packages = ["."]
-  pruneopts = ""
   revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
   version = "v1.2.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault",
-    "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2016-10-01/keyvault",
-    "github.com/Azure/go-autorest/autorest",
-    "github.com/Azure/go-autorest/autorest/adal",
-    "github.com/Azure/go-autorest/autorest/azure",
-    "github.com/golang/glog",
-    "github.com/pkg/errors",
-  ]
+  inputs-digest = "43ac01697aabcda065a24a6a90d4f479d491fad5a11d8812d8e6b55109c60302"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
+++ b/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
@@ -1,3 +1,7 @@
+// Copyright (c) Microsoft and contributors.  All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 package main
 
 import (

--- a/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
+++ b/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
@@ -69,27 +69,30 @@ func (adapter *KeyvaultFlexvolumeAdapter) Run() error {
 			if err != nil {
 				return wrapObjectTypeError(err, objectType, objectName, objectVersion)
 			}
-			err = writeContent([]byte(*secret.Value), objectType, objectName, options.dir)
+			if err = writeContent([]byte(*secret.Value), objectType, objectName, options.dir); err != nil {
+				return err
+			}
 		case VaultTypeKey:
 			keybundle, err := kvClient.GetKey(ctx, *vaultUrl, objectName, objectVersion)
 			if err != nil {
 				return wrapObjectTypeError(err, objectType, objectName, objectVersion)
 			}
 			// NOTE: we are writing the RSA modulus content of the key
-			err = writeContent([]byte(*keybundle.Key.N), objectType, objectName, options.dir)
+			if err = writeContent([]byte(*keybundle.Key.N), objectType, objectName, options.dir); err != nil {
+				return err
+			}
 		case VaultTypeCertificate:
 			certbundle, err := kvClient.GetCertificate(ctx, *vaultUrl, objectName, objectVersion)
 			if err != nil {
 				return wrapObjectTypeError(err, objectType, objectName, objectVersion)
 			}
-			err = writeContent(*certbundle.Cer, objectType, objectName, options.dir)
+			if err = writeContent(*certbundle.Cer, objectType, objectName, options.dir); err != nil {
+				return err
+			}
 		default:
-			err := errors.Errorf("Invalid vaultObjectTypes. Should be secret, key, or cert")
-		}
-
-		//handle writeContent and default case error
-		if err != nil {
-			return wrapObjectTypeError(err, objectType, objectName, objectVersion)
+			if err := errors.Errorf("Invalid vaultObjectTypes. Should be secret, key, or cert"); err != nil {
+				return wrapObjectTypeError(err, objectType, objectName, objectVersion)
+			}
 		}
 	}
 

--- a/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
+++ b/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+
+	kv "github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
+	kvmgmt "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2016-10-01/keyvault"
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+)
+
+// KeyvaultFlexvolumeAdapter encapsulates the logic to connect to keyvault using provided identity,
+// extract keys, secrets and certificate and write them on disk in the provided directory.
+type KeyvaultFlexvolumeAdapter struct {
+	ctx     context.Context
+	options Option
+}
+
+//Run fetches the specified objects from keyvault and writes them on dir
+func (adapter *KeyvaultFlexvolumeAdapter) Run() error {
+	options := adapter.options
+	ctx := adapter.ctx
+	if options.showVersion {
+		fmt.Printf("%s %s\n", program, version)
+		fmt.Printf("%s \n", options.subscriptionId)
+	}
+
+	_, err := os.Lstat(options.dir)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get directory %s", options.dir)
+	}
+
+	glog.Infof("starting the %s, %s", program, version)
+
+	vaultUrl, err := adapter.getVaultURL()
+	if err != nil {
+		return errors.Wrap(err, "failed to get vault")
+	}
+
+	kvClient, err := adapter.initializeKvClient()
+	if err != nil {
+		return errors.Wrap(err, "failed to get keyvaultClient")
+	}
+
+	objectTypes := strings.Split(options.vaultObjectTypes, objectsSep)
+	objectNames := strings.Split(options.vaultObjectNames, objectsSep)
+	numOfObjects := len(objectNames)
+
+	// objectVersions are optional so we take as much as we can
+	objectVersions := make([]string, numOfObjects)
+	for index, value := range strings.Split(options.vaultObjectVersions, objectsSep) {
+		objectVersions[index] = value
+	}
+
+	for i := 0; i < numOfObjects; i++ {
+		objectType := objectTypes[i]
+		objectName := objectNames[i]
+		objectVersion := objectVersions[i]
+
+		glog.V(0).Infof("retrieving %s %s (version: %s)", objectType, objectName, objectVersion)
+		switch objectType {
+		case VaultTypeSecret:
+			secret, err := kvClient.GetSecret(ctx, *vaultUrl, objectName, objectVersion)
+			if err != nil {
+				return wrapObjectTypeError(err, objectType, objectName, objectVersion)
+			}
+			return writeContent([]byte(*secret.Value), objectType, objectName, options.dir)
+		case VaultTypeKey:
+			keybundle, err := kvClient.GetKey(ctx, *vaultUrl, objectName, objectVersion)
+			if err != nil {
+				return wrapObjectTypeError(err, objectType, objectName, objectVersion)
+			}
+			// NOTE: we are writing the RSA modulus content of the key
+			return writeContent([]byte(*keybundle.Key.N), objectType, objectName, options.dir)
+		case VaultTypeCertificate:
+			certbundle, err := kvClient.GetCertificate(ctx, *vaultUrl, objectName, objectVersion)
+			if err != nil {
+				return wrapObjectTypeError(err, objectType, objectName, objectVersion)
+			}
+			return writeContent(*certbundle.Cer, objectType, objectName, options.dir)
+		default:
+			return errors.Errorf("Invalid vaultObjectTypes. Should be secret, key, or cert")
+		}
+	}
+
+	return nil
+}
+
+func (adapter *KeyvaultFlexvolumeAdapter) initializeKvClient() (*kv.BaseClient, error) {
+	kvClient := kv.New()
+	options := adapter.options
+
+	token, err := GetKeyvaultToken(AuthGrantType(), options.cloudName, options.tenantId, options.usePodIdentity, options.aADClientSecret, options.aADClientID, options.podName, options.podNamespace)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get key vault token")
+	}
+
+	kvClient.Authorizer = token
+	return &kvClient, nil
+}
+
+func wrapObjectTypeError(err error, objectType string, objectName string, objectVersion string) error {
+	return errors.Wrapf(err, "failed to get objectType:%s, objetName:%s, objectVersion:%s", objectType, objectName, objectVersion)
+}
+
+func writeContent(objectContent []byte, objectType string, objectName string, dir string) error {
+	if err := ioutil.WriteFile(path.Join(dir, objectName), objectContent, permission); err != nil {
+		return errors.Wrapf(err, "azure KeyVault failed to write %s %s at %s", objectType, objectName, dir)
+	}
+	glog.V(0).Infof("azure KeyVault wrote %s %s at %s", objectType, objectName, dir)
+	return nil
+}
+
+func (adapter *KeyvaultFlexvolumeAdapter) getVaultURL() (vaultUrl *string, err error) {
+	glog.Infof("subscriptionID: %s", adapter.options.subscriptionId)
+	glog.Infof("vaultName: %s", adapter.options.vaultName)
+	glog.Infof("resourceGroup: %s", adapter.options.resourceGroup)
+
+	vaultsClient := kvmgmt.NewVaultsClient(adapter.options.subscriptionId)
+	token, tokenErr := GetManagementToken(AuthGrantType(),
+		adapter.options.cloudName,
+		adapter.options.tenantId,
+		adapter.options.usePodIdentity,
+		adapter.options.aADClientSecret,
+		adapter.options.aADClientID,
+		adapter.options.podName,
+		adapter.options.podNamespace)
+	if tokenErr != nil {
+		return nil, errors.Wrapf(err, "failed to get management token")
+	}
+	vaultsClient.Authorizer = token
+	vault, err := vaultsClient.Get(adapter.ctx, adapter.options.resourceGroup, adapter.options.vaultName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get vault %s", adapter.options.vaultName)
+	}
+	return vault.Properties.VaultURI, nil
+}

--- a/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
+++ b/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
@@ -69,22 +69,26 @@ func (adapter *KeyvaultFlexvolumeAdapter) Run() error {
 			if err != nil {
 				return wrapObjectTypeError(err, objectType, objectName, objectVersion)
 			}
-			writeContent([]byte(*secret.Value), objectType, objectName, options.dir)
+			err = writeContent([]byte(*secret.Value), objectType, objectName, options.dir)
 		case VaultTypeKey:
 			keybundle, err := kvClient.GetKey(ctx, *vaultUrl, objectName, objectVersion)
 			if err != nil {
 				return wrapObjectTypeError(err, objectType, objectName, objectVersion)
 			}
 			// NOTE: we are writing the RSA modulus content of the key
-			writeContent([]byte(*keybundle.Key.N), objectType, objectName, options.dir)
+			err = writeContent([]byte(*keybundle.Key.N), objectType, objectName, options.dir)
 		case VaultTypeCertificate:
 			certbundle, err := kvClient.GetCertificate(ctx, *vaultUrl, objectName, objectVersion)
 			if err != nil {
 				return wrapObjectTypeError(err, objectType, objectName, objectVersion)
 			}
-			writeContent(*certbundle.Cer, objectType, objectName, options.dir)
+			err = writeContent(*certbundle.Cer, objectType, objectName, options.dir)
 		default:
 			err := errors.Errorf("Invalid vaultObjectTypes. Should be secret, key, or cert")
+		}
+
+		//handle writeContent and default case error
+		if err != nil {
 			return wrapObjectTypeError(err, objectType, objectName, objectVersion)
 		}
 	}

--- a/azurekeyvault-flexvolume/main.go
+++ b/azurekeyvault-flexvolume/main.go
@@ -102,7 +102,6 @@ func parseConfigs() (*Option, error) {
 	flag.StringVar(&options.podNamespace, "podNamespace", "", "Namespace of the pod")
 
 	flag.Parse()
-	fmt.Println(options.vaultName)
 
 	err := Validate(options)
 	return &options, err
@@ -135,7 +134,7 @@ func Validate(options Option) error {
 
 	if strings.Count(options.vaultObjectNames, objectsSep) !=
 		strings.Count(options.vaultObjectTypes, objectsSep) {
-		return fmt.Errorf("-vaultObjectNames and -vaultObjectTypes are not matching")
+		return fmt.Errorf("-vaultObjectNames and -vaultObjectTypes do not have the same number of items")
 	}
 
 	if options.usePodIdentity == false {

--- a/azurekeyvault-flexvolume/main.go
+++ b/azurekeyvault-flexvolume/main.go
@@ -9,16 +9,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
-	"path"
 	"strings"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
-
-	kv "github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
-	kvmgmt "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2016-10-01/keyvault"
 )
 
 const (
@@ -72,13 +66,6 @@ type Option struct {
 	podNamespace string
 }
 
-// KeyvaultFlexvolumeAdapter encapsulates the logic to connect to keyvault using provided identity,
-// extract keys, secrets and certificate and write them on disk in the provided directory.
-type KeyvaultFlexvolumeAdapter struct {
-	ctx     context.Context
-	options Option
-}
-
 func main() {
 	context := context.Background()
 	options, err := parseConfigs()
@@ -94,101 +81,6 @@ func main() {
 	}
 	glog.Flush()
 	os.Exit(0)
-}
-
-//Run fetches the specified objects from keyvault and writes them on dir
-func (adapter *KeyvaultFlexvolumeAdapter) Run() error {
-	options := adapter.options
-	ctx := adapter.ctx
-	if options.showVersion {
-		fmt.Printf("%s %s\n", program, version)
-		fmt.Printf("%s \n", options.subscriptionId)
-	}
-
-	_, err := os.Lstat(options.dir)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get directory %s", options.dir)
-	}
-
-	glog.Infof("starting the %s, %s", program, version)
-
-	vaultUrl, err := adapter.getVaultURL()
-	if err != nil {
-		return errors.Wrap(err, "failed to get vault")
-	}
-
-	kvClient, err := adapter.initializeKvClient()
-	if err != nil {
-		return errors.Wrap(err, "failed to get keyvaultClient")
-	}
-
-	objectTypes := strings.Split(options.vaultObjectTypes, objectsSep)
-	objectNames := strings.Split(options.vaultObjectNames, objectsSep)
-	numOfObjects := len(objectNames)
-
-	// objectVersions are optional so we take as much as we can
-	objectVersions := make([]string, numOfObjects)
-	for index, value := range strings.Split(options.vaultObjectVersions, objectsSep) {
-		objectVersions[index] = value
-	}
-
-	for i := 0; i < numOfObjects; i++ {
-		objectType := objectTypes[i]
-		objectName := objectNames[i]
-		objectVersion := objectVersions[i]
-
-		glog.V(0).Infof("retrieving %s %s (version: %s)", objectType, objectName, objectVersion)
-		switch objectType {
-		case VaultTypeSecret:
-			secret, err := kvClient.GetSecret(ctx, *vaultUrl, objectName, objectVersion)
-			if err != nil {
-				return wrapObjectTypeError(err, objectType, objectName, objectVersion)
-			}
-			return writeContent([]byte(*secret.Value), objectType, objectName, options.dir)
-		case VaultTypeKey:
-			keybundle, err := kvClient.GetKey(ctx, *vaultUrl, objectName, objectVersion)
-			if err != nil {
-				return wrapObjectTypeError(err, objectType, objectName, objectVersion)
-			}
-			// NOTE: we are writing the RSA modulus content of the key
-			return writeContent([]byte(*keybundle.Key.N), objectType, objectName, options.dir)
-		case VaultTypeCertificate:
-			certbundle, err := kvClient.GetCertificate(ctx, *vaultUrl, objectName, objectVersion)
-			if err != nil {
-				return wrapObjectTypeError(err, objectType, objectName, objectVersion)
-			}
-			return writeContent(*certbundle.Cer, objectType, objectName, options.dir)
-		default:
-			return errors.Errorf("Invalid vaultObjectTypes. Should be secret, key, or cert")
-		}
-	}
-
-	return nil
-}
-
-func (adapter *KeyvaultFlexvolumeAdapter) initializeKvClient() (*kv.BaseClient, error) {
-	kvClient := kv.New()
-	options := adapter.options
-
-	token, err := GetKeyvaultToken(AuthGrantType(), options.cloudName, options.tenantId, options.usePodIdentity, options.aADClientSecret, options.aADClientID, options.podName, options.podNamespace)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get key vault token")
-	}
-
-	kvClient.Authorizer = token
-	return &kvClient, nil
-}
-
-func wrapObjectTypeError(err error, objectType string, objectName string, objectVersion string) error {
-	return errors.Wrapf(err, "failed to get objectType:%s, objetName:%s, objectVersion:%s", objectType, objectName, objectVersion)
-}
-
-func writeContent(objectContent []byte, objectType string, objectName string, dir string) error {
-	if err := ioutil.WriteFile(path.Join(dir, objectName), objectContent, permission); err != nil {
-		return errors.Wrapf(err, "azure KeyVault failed to write %s %s at %s", objectType, objectName, dir)
-	}
-	glog.V(0).Infof("azure KeyVault wrote %s %s at %s", objectType, objectName, dir)
-	return nil
 }
 
 func parseConfigs() (*Option, error) {
@@ -270,29 +162,4 @@ func Validate(options Option) error {
 	}
 
 	return nil
-}
-
-func (adapter *KeyvaultFlexvolumeAdapter) getVaultURL() (vaultUrl *string, err error) {
-	glog.Infof("subscriptionID: %s", adapter.options.subscriptionId)
-	glog.Infof("vaultName: %s", adapter.options.vaultName)
-	glog.Infof("resourceGroup: %s", adapter.options.resourceGroup)
-
-	vaultsClient := kvmgmt.NewVaultsClient(adapter.options.subscriptionId)
-	token, tokenErr := GetManagementToken(AuthGrantType(),
-		adapter.options.cloudName,
-		adapter.options.tenantId,
-		adapter.options.usePodIdentity,
-		adapter.options.aADClientSecret,
-		adapter.options.aADClientID,
-		adapter.options.podName,
-		adapter.options.podNamespace)
-	if tokenErr != nil {
-		return nil, errors.Wrapf(err, "failed to get management token")
-	}
-	vaultsClient.Authorizer = token
-	vault, err := vaultsClient.Get(adapter.ctx, adapter.options.resourceGroup, adapter.options.vaultName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get vault %s", adapter.options.vaultName)
-	}
-	return vault.Properties.VaultURI, nil
 }

--- a/azurekeyvault-flexvolume/main.go
+++ b/azurekeyvault-flexvolume/main.go
@@ -71,18 +71,32 @@ type Option struct {
 	podNamespace string
 }
 
+//KeyvaultFlexvolumeAdapter
+type KeyvaultFlexvolumeAdapter struct {
+	ctx     context.Context
+	options Option
+}
+
 var (
 	options Option
 )
 
 func main() {
-	ctx := context.Background()
+	context := context.Background()
 
 	if err := parseConfigs(); err != nil {
 		fmt.Printf("\n %s\n", err)
 		os.Exit(1)
 	}
 
+	adapter := &KeyvaultFlexvolumeAdapter{ctx: context, options: options}
+	adapter.Run()
+
+}
+
+func (adapter *KeyvaultFlexvolumeAdapter) Run() {
+	options := adapter.options
+	ctx := adapter.ctx
 	if options.showVersion {
 		fmt.Printf("%s %s\n", program, version)
 		fmt.Printf("%s \n", options.subscriptionId)

--- a/azurekeyvault-flexvolume/main.go
+++ b/azurekeyvault-flexvolume/main.go
@@ -83,7 +83,8 @@ func main() {
 	context := context.Background()
 	options, err := parseConfigs()
 	if err != nil {
-		glog.Fatalf("[error] : %s", err)
+		glog.Errorf("[error] : %s", err)
+		os.Exit(1)
 	}
 
 	adapter := &KeyvaultFlexvolumeAdapter{ctx: context, options: *options}
@@ -91,6 +92,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("[error] : %s", err)
 	}
+	glog.Flush()
 	os.Exit(0)
 }
 
@@ -210,58 +212,64 @@ func parseConfigs() (*Option, error) {
 	flag.Parse()
 	fmt.Println(options.vaultName)
 
+	err := Validate(options)
+	return &options, err
+}
+
+func Validate(options Option) error {
 	if options.vaultName == "" {
-		return nil, fmt.Errorf("-vaultName is not set")
+		return fmt.Errorf("-vaultName is not set")
 	}
 
 	if options.vaultObjectNames == "" {
-		return nil, fmt.Errorf("-vaultObjectNames is not set")
+		return fmt.Errorf("-vaultObjectNames is not set")
 	}
 
 	if options.resourceGroup == "" {
-		return nil, fmt.Errorf("-resourceGroup is not set")
+		return fmt.Errorf("-resourceGroup is not set")
 	}
 
 	if options.subscriptionId == "" {
-		return nil, fmt.Errorf("-subscriptionId is not set")
+		return fmt.Errorf("-subscriptionId is not set")
 	}
 
 	if options.dir == "" {
-		return nil, fmt.Errorf("-dir is not set")
+		return fmt.Errorf("-dir is not set")
 	}
 
 	if options.tenantId == "" {
-		return nil, fmt.Errorf("-tenantId is not set")
+		return fmt.Errorf("-tenantId is not set")
 	}
 
 	if strings.Count(options.vaultObjectNames, objectsSep) !=
 		strings.Count(options.vaultObjectTypes, objectsSep) {
-		return nil, fmt.Errorf("-vaultObjectNames and -vaultObjectTypes are not matching")
+		return fmt.Errorf("-vaultObjectNames and -vaultObjectTypes are not matching")
 	}
 
 	if options.usePodIdentity == false {
 		if options.aADClientID == "" {
-			return nil, fmt.Errorf("-aADClientID is not set")
+			return fmt.Errorf("-aADClientID is not set")
 		}
 		if options.aADClientSecret == "" {
-			return nil, fmt.Errorf("-aADClientSecret is not set")
+			return fmt.Errorf("-aADClientSecret is not set")
 		}
 	} else {
 		if options.podName == "" {
-			return nil, fmt.Errorf("-podName is not set")
+			return fmt.Errorf("-podName is not set")
 		}
 		if options.podNamespace == "" {
-			return nil, fmt.Errorf("-podNamespace is not set")
+			return fmt.Errorf("-podNamespace is not set")
 		}
 	}
 
 	// validate all object types
 	for _, objectType := range strings.Split(options.vaultObjectTypes, objectsSep) {
 		if objectType != VaultTypeSecret && objectType != VaultTypeKey && objectType != VaultTypeCertificate {
-			return nil, fmt.Errorf("-vaultObjectType is invalid, should be set to secret, key, or certificate")
+			return fmt.Errorf("-vaultObjectType is invalid, should be set to secret, key, or certificate")
 		}
 	}
-	return &options, nil
+
+	return nil
 }
 
 func (adapter *KeyvaultFlexvolumeAdapter) getVaultURL() (vaultUrl *string, err error) {


### PR DESCRIPTION
The goal of this PR is to clean up the main.go code to extract the logic and make it testable.

- [x]  add `KeyvaultFlexvolumeAdapter` struct
- [x]  move `main()` logic into a `Run()` function applied to the struct
- [x]  add package `github.com/pkg/errors`
    - provides the commonly used `errors.Wrapf()` 
- [x]  wrap and return all `errors` from `Run()`
    - simplifies error handling
- [x]  use `glog.Fatalf` instead of `Exit(1)`
    - Note: this changes the error exit code from `1` to `255` as per `glog.Fatalf` definition
    - Provides stacktrace on errors

TODO :

- [x] Apply functions to the adapter
- [x] Move `KeyvaultFlexvolumeAdapter` in its own file
- [ ] Add first tests

More : 
- [ ] Abstract `writeContent` to enable testing
