### PR TITLE
fix tls sample doc typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ testvalue
 
 ### Specific use cases ###
 
-- [A detailed example for using a KeyVault certificate to setup an SSL entrypoint with Traefik](docs/traefik-tls-certificate)
+- [A detailed example for using a KeyVault certificate to setup an SSL entrypoint with Traefik](docs/traefik-tls-certificate.md)
 
 # About KeyVault 
 


### PR DESCRIPTION
- The latest TLS docs had some typos and syntax issues.
- The root README.md linked to the yaml folder, fixed to link to the write-up
