### PR TITLE
Improved error wrapping and add support for object alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ secretRef:
 |usepodidentity|no|specify access mode: service principal or pod identity|"false"|
 |keyvaultname|yes|name of KeyVault instance|""|
 |keyvaultobjectnames|yes|names of KeyVault objects to access|""|
+|keyvaultobjectaliases|no|filenames to use when writing the objects|keyvaultobjectnames|
 |keyvaultobjecttypes|yes|types of KeyVault objects: secret, key or cert|""|
 |keyvaultobjectversions|no|versions of KeyVault objects, if not provided, will use latest|""|
 |resourcegroup|yes|name of resource group containing key vault instance|""|
@@ -127,6 +128,7 @@ spec:
         usepodidentity: "false"
         keyvaultname: "testkeyvault"
         keyvaultobjectnames: "testsecret"
+        keyvaultobjectaliases: "secret.json" # optional
         keyvaultobjecttypes: secret # OPTIONS: secret, key, cert
         keyvaultobjectversions: "testversion"
         resourcegroup: "testresourcegroup"

--- a/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
+++ b/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
@@ -60,12 +60,12 @@ func (adapter *KeyvaultFlexvolumeAdapter) Run() error {
 		objectName := objectNames[i]
 		// default to the objectName and override if aliases are available
 		fileName := path.Join(options.dir, objectNames[i])
-		if len(objectAliases) == len(objectNames) {
+		if options.vaultObjectAliases != "" && len(objectAliases) == len(objectNames) {
 			fileName = path.Join(options.dir, objectAliases[i])
 		}
 		// objectVersions are optional so we take as much as we can
 		objectVersion := ""
-		if len(objectVersions) == len(objectNames) {
+		if options.vaultObjectVersions != "" && len(objectVersions) == len(objectNames) {
 			objectVersion = objectVersions[i]
 		}
 		glog.V(0).Infof("retrieving %s %s (version: %s)", objectType, objectName, objectVersion)

--- a/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
+++ b/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
@@ -52,11 +52,17 @@ func (adapter *KeyvaultFlexvolumeAdapter) Run() error {
 
 	objectTypes := strings.Split(options.vaultObjectTypes, objectsSep)
 	objectNames := strings.Split(options.vaultObjectNames, objectsSep)
+	objectAliases := strings.Split(options.vaultObjectAliases, objectsSep)
 	objectVersions := strings.Split(options.vaultObjectVersions, objectsSep)
 
 	for i := range objectNames {
 		objectType := objectTypes[i]
 		objectName := objectNames[i]
+		// default to the objectName and override if aliases are available
+		fileName := path.Join(options.dir, objectNames[i])
+		if len(objectAliases) == len(objectNames) {
+			fileName = path.Join(options.dir, objectAliases[i])
+		}
 		// objectVersions are optional so we take as much as we can
 		objectVersion := ""
 		if len(objectVersions) == len(objectNames) {
@@ -69,8 +75,8 @@ func (adapter *KeyvaultFlexvolumeAdapter) Run() error {
 			if err != nil {
 				return wrapObjectTypeError(err, objectType, objectName, objectVersion)
 			}
-			if err = writeContent([]byte(*secret.Value), objectType, objectName, options.dir); err != nil {
-				return err
+			if err = ioutil.WriteFile(fileName, []byte(*secret.Value), permission); err != nil {
+				return errors.Wrapf(err, "azure KeyVault failed to write secret %s to %s", objectName, fileName)
 			}
 		case VaultTypeKey:
 			keybundle, err := kvClient.GetKey(ctx, *vaultUrl, objectName, objectVersion)
@@ -78,22 +84,22 @@ func (adapter *KeyvaultFlexvolumeAdapter) Run() error {
 				return wrapObjectTypeError(err, objectType, objectName, objectVersion)
 			}
 			// NOTE: we are writing the RSA modulus content of the key
-			if err = writeContent([]byte(*keybundle.Key.N), objectType, objectName, options.dir); err != nil {
-				return err
+			if err = ioutil.WriteFile(fileName, []byte(*keybundle.Key.N), permission); err != nil {
+				return errors.Wrapf(err, "azure KeyVault failed to write key %s to %s", objectName, fileName)
 			}
 		case VaultTypeCertificate:
 			certbundle, err := kvClient.GetCertificate(ctx, *vaultUrl, objectName, objectVersion)
 			if err != nil {
 				return wrapObjectTypeError(err, objectType, objectName, objectVersion)
 			}
-			if err = writeContent(*certbundle.Cer, objectType, objectName, options.dir); err != nil {
-				return err
+			if err = ioutil.WriteFile(fileName, *certbundle.Cer, permission); err != nil {
+				return errors.Wrapf(err, "azure KeyVault failed to write certificate %s to %s", objectName, fileName)
 			}
 		default:
-			if err := errors.Errorf("Invalid vaultObjectTypes. Should be secret, key, or cert"); err != nil {
-				return wrapObjectTypeError(err, objectType, objectName, objectVersion)
-			}
+			err = errors.Errorf("Invalid vaultObjectTypes. Should be secret, key, or cert")
+			return wrapObjectTypeError(err, objectType, objectName, objectVersion)
 		}
+		glog.V(0).Infof("azure KeyVault wrote %s %s at %s", objectType, objectName, fileName)
 	}
 
 	return nil
@@ -117,14 +123,6 @@ func (adapter *KeyvaultFlexvolumeAdapter) initializeKvClient() (*kv.BaseClient, 
 
 func wrapObjectTypeError(err error, objectType string, objectName string, objectVersion string) error {
 	return errors.Wrapf(err, "failed to get objectType:%s, objetName:%s, objectVersion:%s", objectType, objectName, objectVersion)
-}
-
-func writeContent(objectContent []byte, objectType string, objectName string, dir string) error {
-	if err := ioutil.WriteFile(path.Join(dir, objectName), objectContent, permission); err != nil {
-		return errors.Wrapf(err, "azure KeyVault failed to write %s %s at %s", objectType, objectName, dir)
-	}
-	glog.V(0).Infof("azure KeyVault wrote %s %s at %s", objectType, objectName, dir)
-	return nil
 }
 
 func (adapter *KeyvaultFlexvolumeAdapter) getVaultURL() (vaultUrl *string, err error) {

--- a/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
+++ b/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
@@ -101,7 +101,9 @@ func (adapter *KeyvaultFlexvolumeAdapter) Run() error {
 
 func (adapter *KeyvaultFlexvolumeAdapter) initializeKvClient() (*kv.BaseClient, error) {
 	kvClient := kv.New()
-	kvClient.AddToUserAgent("k8s-keyvault-flexvol")
+	if err := kvClient.AddToUserAgent("k8s-keyvault-flexvol"); err != nil {
+		return nil, errors.Wrap(err, "failed to add user agent to keyvault client")
+	}
 	options := adapter.options
 
 	token, err := GetKeyvaultToken(AuthGrantType(), options.cloudName, options.tenantId, options.usePodIdentity, options.aADClientSecret, options.aADClientID, options.podName, options.podNamespace)
@@ -140,7 +142,7 @@ func (adapter *KeyvaultFlexvolumeAdapter) getVaultURL() (vaultUrl *string, err e
 		adapter.options.podName,
 		adapter.options.podNamespace)
 	if tokenErr != nil {
-		return nil, errors.Wrapf(err, "failed to get management token")
+		return nil, errors.Wrap(err, "failed to get management token")
 	}
 	vaultsClient.Authorizer = token
 	vault, err := vaultsClient.Get(adapter.ctx, adapter.options.resourceGroup, adapter.options.vaultName)

--- a/azurekeyvault-flexvolume/main.go
+++ b/azurekeyvault-flexvolume/main.go
@@ -38,6 +38,8 @@ type Option struct {
 	vaultName string
 	// the name of the Azure Key Vault objects
 	vaultObjectNames string
+	// the filenames the objects will be written to
+	vaultObjectAliases string
 	// the versions of the Azure Key Vault objects
 	vaultObjectVersions string
 	// the types of the Azure Key Vault objects
@@ -87,6 +89,7 @@ func parseConfigs() (*Option, error) {
 	var options Option
 	flag.StringVar(&options.vaultName, "vaultName", "", "Name of Azure Key Vault instance.")
 	flag.StringVar(&options.vaultObjectNames, "vaultObjectNames", "", "Names of Azure Key Vault objects, semi-colon separated.")
+	flag.StringVar(&options.vaultObjectAliases, "vaultObjectAliases", "", "Filenames to write the Azure Key Vault objects to, semi-colon separated.")
 	flag.StringVar(&options.vaultObjectTypes, "vaultObjectTypes", "", "Types of Azure Key Vault objects, semi-colon separated.")
 	flag.StringVar(&options.vaultObjectVersions, "vaultObjectVersions", "", "Versions of Azure Key Vault objects, semi-colon separated.")
 	flag.StringVar(&options.resourceGroup, "resourceGroup", "", "Resource group name of Azure Key Vault.")
@@ -135,6 +138,11 @@ func Validate(options Option) error {
 	if strings.Count(options.vaultObjectNames, objectsSep) !=
 		strings.Count(options.vaultObjectTypes, objectsSep) {
 		return fmt.Errorf("-vaultObjectNames and -vaultObjectTypes do not have the same number of items")
+	}
+
+	if len(options.vaultObjectAliases) > 0 &&
+		(strings.Count(options.vaultObjectAliases, objectsSep) != strings.Count(options.vaultObjectAliases, objectsSep)) {
+		return fmt.Errorf("-vaultObjectNames and -vaultObjectAliases do not have the same number of items")
 	}
 
 	if options.usePodIdentity == false {

--- a/azurekeyvault-flexvolume/main.go
+++ b/azurekeyvault-flexvolume/main.go
@@ -67,14 +67,14 @@ type Option struct {
 }
 
 func main() {
-	context := context.Background()
+	ctx := context.Background()
 	options, err := parseConfigs()
 	if err != nil {
 		glog.Errorf("[error] : %s", err)
 		os.Exit(1)
 	}
 
-	adapter := &KeyvaultFlexvolumeAdapter{ctx: context, options: *options}
+	adapter := &KeyvaultFlexvolumeAdapter{ctx: ctx, options: *options}
 	err = adapter.Run()
 	if err != nil {
 		glog.Fatalf("[error] : %s", err)

--- a/deployment/flexvol-installer/kv
+++ b/deployment/flexvol-installer/kv
@@ -154,8 +154,8 @@ mount() {
 		exit 1
 	fi
 
-	echo "`date` $KVFV -logtostderr=1 -vaultName=${KEYVAULT_NAME} -vaultObjectNames=${KEYVAULT_OBJECT_NAMES} -resourceGroup=${RESOURCE_GROUP} -dir=${MNTPATH} -subscriptionId=${SUBSCRIPTION_ID} -cloudName=${CLOUD_NAME} -tenantId=${TENANT_ID} -aADClientSecret=${CLIENTSECRET} -aADClientID=${CLIENTID} -usePodIdentity=${USE_POD_IDENTITY} -podNamespace=${PODNAMESPACE} -podName=${PODNAME} -vaultObjectVersions=${KEYVAULT_OBJECT_VERSIONS} -vaultObjectTypes=${KEYVAULT_OBJECT_TYPES}" >> $LOG
-	$KVFV -logtostderr=1 -vaultName=${KEYVAULT_NAME} -vaultObjectNames=${KEYVAULT_OBJECT_NAMES} -resourceGroup=${RESOURCE_GROUP} -dir=${MNTPATH} -subscriptionId=${SUBSCRIPTION_ID} -cloudName=${CLOUD_NAME} -tenantId=${TENANT_ID} -aADClientSecret=${CLIENTSECRET} -aADClientID=${CLIENTID} -usePodIdentity=${USE_POD_IDENTITY} -podNamespace=${PODNAMESPACE} -podName=${PODNAME} -vaultObjectVersions=${KEYVAULT_OBJECT_VERSIONS} -vaultObjectTypes=${KEYVAULT_OBJECT_TYPES} >> $LOG 2>&1
+	echo "`date` $KVFV -logtostderr=1 -vaultName=${KEYVAULT_NAME} -vaultObjectNames=${KEYVAULT_OBJECT_NAMES} -vaultObjectAliases=${ALIAS} -resourceGroup=${RESOURCE_GROUP} -dir=${MNTPATH} -subscriptionId=${SUBSCRIPTION_ID} -cloudName=${CLOUD_NAME} -tenantId=${TENANT_ID} -aADClientSecret=${CLIENTSECRET} -aADClientID=${CLIENTID} -usePodIdentity=${USE_POD_IDENTITY} -podNamespace=${PODNAMESPACE} -podName=${PODNAME} -vaultObjectVersions=${KEYVAULT_OBJECT_VERSIONS} -vaultObjectTypes=${KEYVAULT_OBJECT_TYPES}" >> $LOG
+	$KVFV -logtostderr=1 -vaultName=${KEYVAULT_NAME} -vaultObjectNames=${KEYVAULT_OBJECT_NAMES} -vaultObjectAliases=${ALIAS} -resourceGroup=${RESOURCE_GROUP} -dir=${MNTPATH} -subscriptionId=${SUBSCRIPTION_ID} -cloudName=${CLOUD_NAME} -tenantId=${TENANT_ID} -aADClientSecret=${CLIENTSECRET} -aADClientID=${CLIENTID} -usePodIdentity=${USE_POD_IDENTITY} -podNamespace=${PODNAMESPACE} -podName=${PODNAME} -vaultObjectVersions=${KEYVAULT_OBJECT_VERSIONS} -vaultObjectTypes=${KEYVAULT_OBJECT_TYPES} >> $LOG 2>&1
 	
 	if [ $? -ne 0 ] ; then
 		errorLog=`tail -n 1 "${LOG}" | sed 's/.*Message=//' | tr -d '"'`

--- a/deployment/flexvol-installer/kv
+++ b/deployment/flexvol-installer/kv
@@ -57,7 +57,7 @@ mount() {
 	# Optional
 	CLOUD_NAME="$(echo "$2"|"$JQ" -r '.cloudname //empty')"
 	KEYVAULT_OBJECT_VERSIONS="$(echo "$2"|"$JQ" -r '.keyvaultobjectversions //empty')"
-	ALIAS="$(echo "$2"|"$JQ" -r '.alias //empty')"
+	KEYVAULT_OBJECT_ALIASES="$(echo "$2"|"$JQ" -r '.keyvaultobjectaliases //empty')"
 	
     # backward compatibility (should be deprecated!)
 	if [ -z "${KEYVAULT_OBJECT_NAMES}" ]; then
@@ -154,8 +154,8 @@ mount() {
 		exit 1
 	fi
 
-	echo "`date` $KVFV -logtostderr=1 -vaultName=${KEYVAULT_NAME} -vaultObjectNames=${KEYVAULT_OBJECT_NAMES} -vaultObjectAliases=${ALIAS} -resourceGroup=${RESOURCE_GROUP} -dir=${MNTPATH} -subscriptionId=${SUBSCRIPTION_ID} -cloudName=${CLOUD_NAME} -tenantId=${TENANT_ID} -aADClientSecret=${CLIENTSECRET} -aADClientID=${CLIENTID} -usePodIdentity=${USE_POD_IDENTITY} -podNamespace=${PODNAMESPACE} -podName=${PODNAME} -vaultObjectVersions=${KEYVAULT_OBJECT_VERSIONS} -vaultObjectTypes=${KEYVAULT_OBJECT_TYPES}" >> $LOG
-	$KVFV -logtostderr=1 -vaultName=${KEYVAULT_NAME} -vaultObjectNames=${KEYVAULT_OBJECT_NAMES} -vaultObjectAliases=${ALIAS} -resourceGroup=${RESOURCE_GROUP} -dir=${MNTPATH} -subscriptionId=${SUBSCRIPTION_ID} -cloudName=${CLOUD_NAME} -tenantId=${TENANT_ID} -aADClientSecret=${CLIENTSECRET} -aADClientID=${CLIENTID} -usePodIdentity=${USE_POD_IDENTITY} -podNamespace=${PODNAMESPACE} -podName=${PODNAME} -vaultObjectVersions=${KEYVAULT_OBJECT_VERSIONS} -vaultObjectTypes=${KEYVAULT_OBJECT_TYPES} >> $LOG 2>&1
+	echo "`date` $KVFV -logtostderr=1 -vaultName=${KEYVAULT_NAME} -vaultObjectNames=${KEYVAULT_OBJECT_NAMES} -vaultObjectAliases=${KEYVAULT_OBJECT_ALIASES} -resourceGroup=${RESOURCE_GROUP} -dir=${MNTPATH} -subscriptionId=${SUBSCRIPTION_ID} -cloudName=${CLOUD_NAME} -tenantId=${TENANT_ID} -aADClientSecret=${CLIENTSECRET} -aADClientID=${CLIENTID} -usePodIdentity=${USE_POD_IDENTITY} -podNamespace=${PODNAMESPACE} -podName=${PODNAME} -vaultObjectVersions=${KEYVAULT_OBJECT_VERSIONS} -vaultObjectTypes=${KEYVAULT_OBJECT_TYPES}" >> $LOG
+	$KVFV -logtostderr=1 -vaultName=${KEYVAULT_NAME} -vaultObjectNames=${KEYVAULT_OBJECT_NAMES} -vaultObjectAliases=${KEYVAULT_OBJECT_ALIASES} -resourceGroup=${RESOURCE_GROUP} -dir=${MNTPATH} -subscriptionId=${SUBSCRIPTION_ID} -cloudName=${CLOUD_NAME} -tenantId=${TENANT_ID} -aADClientSecret=${CLIENTSECRET} -aADClientID=${CLIENTID} -usePodIdentity=${USE_POD_IDENTITY} -podNamespace=${PODNAMESPACE} -podName=${PODNAME} -vaultObjectVersions=${KEYVAULT_OBJECT_VERSIONS} -vaultObjectTypes=${KEYVAULT_OBJECT_TYPES} >> $LOG 2>&1
 	
 	if [ $? -ne 0 ] ; then
 		errorLog=`tail -n 1 "${LOG}" | sed 's/.*Message=//' | tr -d '"'`

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -36,7 +36,7 @@ The following fields are expected to be part of Flex Vol
 5. KeyVault Object Type: `required`
 6. KeyVault Object Version: `optional` (`empty` == latest version)
 7. Use integrated identity. `optional` (Default `false` (mode #1), true (mode #2))
-8. Alias: `optional` by default keyvault objects are projected with their name, alias is to override the filename.
+8. KeyVault Object Alias: `optional` by default keyvault objects are projected with their name, alias is to override the filename.
 
 ##  Flows
 


### PR DESCRIPTION
Hi,

I needed object aliases so this PR adds that. It works the same as described in concept.md. It also adds some improvements to the error wrapping that helped debugging my deployment

I did initially set the k8s config to be `keyvaultobjectaliases` until I saw concept.md, let me know if you want it renamed.

fixes #51 
fixes #66 
