### PR TITLE
Add GitHub issue templates for bug and feature request

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,9 @@ assignees: ''
 **Expected behavior**
 
 **Key Vault FlexVolume version**
+
 **Access mode: service principal or pod identity**
+
 **Kubernetes version**
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Create a report to help Key Vault FlexVolume improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+
+**Steps To Reproduce**
+
+**Expected behavior**
+
+**Key Vault FlexVolume version**
+
+**Kubernetes version**
+
+**Additional context**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ assignees: ''
 **Expected behavior**
 
 **Key Vault FlexVolume version**
-
+**Access mode: service principal or pod identity**
 **Kubernetes version**
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for Key Vault FlexVolume
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Describe the request**
+
+**Explain why Key Vault FlexVolume needs it**
+
+**Describe the solution you'd like**
+
+**Describe alternatives you've considered**
+
+**Additional context**


### PR DESCRIPTION
Adds separate bug and feature [issue templates](https://help.github.com/en/articles/about-issue-and-pull-request-templates) to the project as recommended by GitHub's [community standards checklist](https://github.com/Azure/kubernetes-keyvault-flexvol/community).

(Derived from Azure/aks-engine#1382. See also Azure/aad-pod-identity#228.)

Here's how it changes the "new issue" UI (in aks-engine):

<img width="1258" alt="Screen Shot 2019-05-31 at 8 45 57 AM" src="https://user-images.githubusercontent.com/73019/58713786-99bf1480-8380-11e9-8b70-dc57b7e1e003.png">

<img width="1121" alt="Screen Shot 2019-05-31 at 8 48 09 AM" src="https://user-images.githubusercontent.com/73019/58713923-dc80ec80-8380-11e9-90b8-e0da456e20e6.png">

