### PR TITLE
Retry calls to pod-identity 

### DIFF
--- a/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
+++ b/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
@@ -41,7 +41,7 @@ func (adapter *KeyvaultFlexvolumeAdapter) Run() error {
 	glog.Infof("starting the %s, %s", program, version)
 
 	vaultUrl, err := adapter.getVaultURL()
-	if err != nil {
+	if err != nil || vaultUrl == nil {
 		return errors.Wrap(err, "failed to get vault")
 	}
 

--- a/azurekeyvault-flexvolume/oauth.go
+++ b/azurekeyvault-flexvolume/oauth.go
@@ -206,7 +206,10 @@ func retryFetchToken(req *http.Request, maxAttempts int) (resp *http.Response, e
 	client := &http.Client{}
 	for attempt < maxAttempts {
 		resp, err = client.Do(req)
-		if err != nil || resp != nil && resp.StatusCode == http.StatusOK {
+
+		// pod-identity calls will be retried in every scenario except when the err is nil
+		// and we get 200 response code.
+		if err == nil && resp != nil && resp.StatusCode == http.StatusOK {
 			return
 		}
 

--- a/azurekeyvault-flexvolume/oauth.go
+++ b/azurekeyvault-flexvolume/oauth.go
@@ -148,6 +148,9 @@ func GetServicePrincipalToken(tenantId string, env *azure.Environment, resource 
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to query NMI")
 		}
+		if resp == nil {
+			return nil, fmt.Errorf("nmi response is nil")
+		}
 		defer func() {
 			if err := resp.Body.Close(); err != nil {
 				fmt.Print("failed to close NMI response body")


### PR DESCRIPTION
Add retry to nmi calls while fetching token.

Retry guidance - https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#retry-guidance