### PR TITLE
docs: add standalone Code of Conduct doc where GH can see it

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,50 @@
+# Microsoft Open Source Code of Conduct
+
+This code of conduct outlines expectations for participation in Microsoft-managed open source communities, as well as steps for reporting unacceptable behavior. We are committed to providing a welcoming and inspiring community for all. People violating this code of conduct may be banned from the community.
+
+Our open source communities strive to:
+
+- **Be friendly and patient:** Remember you might not be communicating in someone else's primary spoken or programming language, and others may not have your level of understanding.
+- **Be welcoming:** Our communities welcome and support people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
+- **Be respectful:** We are a world-wide community of professionals, and we conduct ourselves professionally. Disagreement is no excuse for poor behavior and poor manners. Disrespectful and unacceptable behavior includes, but is not limited to:
+        Violent threats or language.
+        Discriminatory or derogatory jokes and language.
+        Posting sexually explicit or violent material.
+        Posting, or threatening to post, people's personally identifying information ("doxing").
+        Insults, especially those using discriminatory terms or slurs.
+        Behavior that could be perceived as sexual attention.
+        Advocating for or encouraging any of the above behaviors.
+- **Understand disagreements:** Disagreements, both social and technical, are useful learning opportunities. Seek to understand the other viewpoints and resolve differences constructively.
+- This code is not exhaustive or complete. It serves to capture our common understanding of a productive, collaborative environment. We expect the code to be followed in spirit as much as in the letter.
+
+## Scope
+
+This code of conduct applies to all repos and communities for Microsoft-managed open source projects regardless of whether or not the repo explicitly calls out its use of this code. The code also applies in public spaces when an individual is representing a project or its community. Examples include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+Note: Some Microsoft-managed communities have codes of conduct that pre-date this document and issue resolution process. While communities are not required to change their code, they are expected to use the resolution process outlined here. The review team will coordinate with the communities involved to address your concerns.
+
+## Reporting Code of Conduct Issues
+
+We encourage all communities to resolve issues on their own whenever possible. This builds a broader and deeper understanding and ultimately a healthier interaction. In the event that an issue cannot be resolved locally, please feel free to report your concerns by contacting opencode@microsoft.com. Your report will be handled in accordance with the issue resolution process described in the [Code of Conduct FAQ].
+
+In your report please include:
+
+- Your contact information.
+- Names (real, usernames or pseudonyms) of any individuals involved. If there are additional witnesses, please include them as well.
+- Your account of what occurred, and if you believe the incident is ongoing. If there is a publicly available record (e.g. a mailing list archive or a public chat log), please include a link or attachment.
+- Any additional information that may be helpful.
+
+All reports will be reviewed by a multi-person team and will result in a response that is deemed necessary and appropriate to the circumstances. Where additional perspectives are needed, the team may seek insight from others with relevant expertise or experience. The confidentiality of the person reporting the incident will be kept at all times. Involved parties are never part of the review team.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately. If an individual engages in unacceptable behavior, the review team may take any action they deem appropriate, including a permanent ban from the community.
+
+*This code of conduct is based on the [template] established by the [TODO Group] and used by numerous other large communities (e.g., [Facebook], [Yahoo], [Twitter], [GitHub]) and the Scope section from the [Contributor Covenant version 1.4].*
+
+[Code of Conduct FAQ]: https://opensource.microsoft.com/codeofconduct/faq/
+[template]: http://todogroup.org/opencodeofconduct
+[TODO Group]: http://todogroup.org/
+[Facebook]: https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct
+[Yahoo]: https://yahoo.github.io/codeofconduct
+[Twitter]: https://engineering.twitter.com/opensource/code-of-conduct
+[GitHub]: http://todogroup.org/opencodeofconduct/#opensource@github.com
+[Contributor Covenant version 1.4]: http://contributor-covenant.org/version/1/4/


### PR DESCRIPTION
**Reason for Change**:
Adds the Microsoft Open Source Code of Conduct as a standalone document in the project root, as expected by GitHub [community standards](https://github.com/Azure/kubernetes-keyvault-flexvol/community).

**Issue Fixed**:
None, but see also Azure/aks-engine#510

**Notes for Reviewers**:
