### PR TITLE
Fix error check when failed to get token

### DIFF
--- a/azurekeyvault-flexvolume/main.go
+++ b/azurekeyvault-flexvolume/main.go
@@ -48,14 +48,14 @@ type Option struct {
 	resourceGroup string
 	// directory to save the vault objects
 	dir string
-	// subscriptionId to azure
-	subscriptionId string
+	// subscriptionID to azure
+	subscriptionID string
 	// version flag
 	showVersion bool
 	// cloud name
 	cloudName string
 	// tenantID in AAD
-	tenantId string
+	tenantID string
 	// POD AAD Identity flag
 	usePodIdentity bool
 	// AAD app client secret (if not using POD AAD Identity)
@@ -93,11 +93,11 @@ func parseConfigs() (*Option, error) {
 	flag.StringVar(&options.vaultObjectTypes, "vaultObjectTypes", "", "Types of Azure Key Vault objects, semi-colon separated.")
 	flag.StringVar(&options.vaultObjectVersions, "vaultObjectVersions", "", "Versions of Azure Key Vault objects, semi-colon separated.")
 	flag.StringVar(&options.resourceGroup, "resourceGroup", "", "Resource group name of Azure Key Vault.")
-	flag.StringVar(&options.subscriptionId, "subscriptionId", "", "subscriptionId to Azure.")
+	flag.StringVar(&options.subscriptionID, "subscriptionId", "", "subscriptionId to Azure.")
 	flag.StringVar(&options.aADClientID, "aADClientID", "", "aADClientID to Azure.")
 	flag.StringVar(&options.aADClientSecret, "aADClientSecret", "", "aADClientSecret to Azure.")
 	flag.StringVar(&options.cloudName, "cloudName", "", "Type of Azure cloud")
-	flag.StringVar(&options.tenantId, "tenantId", "", "tenantId to Azure")
+	flag.StringVar(&options.tenantID, "tenantId", "", "tenantId to Azure")
 	flag.BoolVar(&options.usePodIdentity, "usePodIdentity", false, "usePodIdentity for using pod identity.")
 	flag.StringVar(&options.dir, "dir", "", "Directory path to write data.")
 	flag.BoolVar(&options.showVersion, "version", true, "Show version.")
@@ -110,6 +110,7 @@ func parseConfigs() (*Option, error) {
 	return &options, err
 }
 
+// Validate volume options
 func Validate(options Option) error {
 	if options.vaultName == "" {
 		return fmt.Errorf("-vaultName is not set")
@@ -123,7 +124,7 @@ func Validate(options Option) error {
 		return fmt.Errorf("-resourceGroup is not set")
 	}
 
-	if options.subscriptionId == "" {
+	if options.subscriptionID == "" {
 		return fmt.Errorf("-subscriptionId is not set")
 	}
 
@@ -131,7 +132,7 @@ func Validate(options Option) error {
 		return fmt.Errorf("-dir is not set")
 	}
 
-	if options.tenantId == "" {
+	if options.tenantID == "" {
 		return fmt.Errorf("-tenantId is not set")
 	}
 

--- a/azurekeyvault-flexvolume/oauth.go
+++ b/azurekeyvault-flexvolume/oauth.go
@@ -81,7 +81,7 @@ func AuthGrantType() OAuthGrantType {
 	return OAuthGrantTypeServicePrincipal
 }
 
-// NMIResponse is the response recieved from aad-pod-identity
+// NMIResponse is the response received from aad-pod-identity
 type NMIResponse struct {
 	Token    adal.Token `json:"token"`
 	ClientID string     `json:"clientid"`

--- a/azurekeyvault-flexvolume/oauth.go
+++ b/azurekeyvault-flexvolume/oauth.go
@@ -76,16 +76,19 @@ type Config struct {
 	ProviderKeyVersion string `json:"providerKeyVersion"`
 }
 
+// AuthGrantType ...
 func AuthGrantType() OAuthGrantType {
 	return OAuthGrantTypeServicePrincipal
 }
 
+// NMIResponse is the response recieved from aad-pod-identity
 type NMIResponse struct {
 	Token    adal.Token `json:"token"`
 	ClientID string     `json:"clientid"`
 }
 
-func GetManagementToken(grantType OAuthGrantType, cloudName string, tenantId string, usePodIdentity bool, aADClientSecret string, aADClientID string, podname string, podns string) (authorizer autorest.Authorizer, err error) {
+// GetManagementToken retrieves a new service principal token
+func GetManagementToken(grantType OAuthGrantType, cloudName, tenantID string, usePodIdentity bool, aADClientSecret, aADClientID, podname, podns string) (authorizer autorest.Authorizer, err error) {
 
 	env, err := ParseAzureEnvironment(cloudName)
 	if err != nil {
@@ -93,7 +96,7 @@ func GetManagementToken(grantType OAuthGrantType, cloudName string, tenantId str
 	}
 
 	rmEndPoint := env.ResourceManagerEndpoint
-	servicePrincipalToken, err := GetServicePrincipalToken(tenantId, env, rmEndPoint, usePodIdentity, aADClientSecret, aADClientID, podname, podns)
+	servicePrincipalToken, err := GetServicePrincipalToken(tenantID, env, rmEndPoint, usePodIdentity, aADClientSecret, aADClientID, podname, podns)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get service principal token")
 	}
@@ -102,7 +105,8 @@ func GetManagementToken(grantType OAuthGrantType, cloudName string, tenantId str
 
 }
 
-func GetKeyvaultToken(grantType OAuthGrantType, cloudName string, tenantId string, usePodIdentity bool, aADClientSecret string, aADClientID string, podname string, podns string) (authorizer autorest.Authorizer, err error) {
+// GetKeyvaultToken retrieves a new service principal token to access keyvault
+func GetKeyvaultToken(grantType OAuthGrantType, cloudName, tenantID string, usePodIdentity bool, aADClientSecret, aADClientID, podname, podns string) (authorizer autorest.Authorizer, err error) {
 
 	env, err := ParseAzureEnvironment(cloudName)
 	if err != nil {
@@ -113,7 +117,7 @@ func GetKeyvaultToken(grantType OAuthGrantType, cloudName string, tenantId strin
 	if '/' == kvEndPoint[len(kvEndPoint)-1] {
 		kvEndPoint = kvEndPoint[:len(kvEndPoint)-1]
 	}
-	servicePrincipalToken, err := GetServicePrincipalToken(tenantId, env, kvEndPoint, usePodIdentity, aADClientSecret, aADClientID, podname, podns)
+	servicePrincipalToken, err := GetServicePrincipalToken(tenantID, env, kvEndPoint, usePodIdentity, aADClientSecret, aADClientID, podname, podns)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get service principal token")
 	}
@@ -123,8 +127,8 @@ func GetKeyvaultToken(grantType OAuthGrantType, cloudName string, tenantId strin
 }
 
 // GetServicePrincipalToken creates a new service principal token based on the configuration
-func GetServicePrincipalToken(tenantId string, env *azure.Environment, resource string, usePodIdentity bool, aADClientSecret string, aADClientID string, podname string, podns string) (*adal.ServicePrincipalToken, error) {
-	oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, tenantId)
+func GetServicePrincipalToken(tenantID string, env *azure.Environment, resource string, usePodIdentity bool, aADClientSecret, aADClientID, podname, podns string) (*adal.ServicePrincipalToken, error) {
+	oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, tenantID)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed creating the OAuth config")
 	}
@@ -135,7 +139,7 @@ func GetServicePrincipalToken(tenantId string, env *azure.Environment, resource 
 	// Then nmi makes an adal request to get a token for the resource in the request, returns the `token` and the `clientid` as a reponse to the flexvolume request.
 
 	if usePodIdentity {
-		glog.V(0).Infoln("azure: using pod identity to retrieve token")
+		glog.V(0).Infof("azure: using pod identity to retrieve token for %s/%s", podns, podname)
 
 		endpoint := fmt.Sprintf("%s?resource=%s", nmiendpoint, resource)
 		req, err := http.NewRequest("GET", endpoint, nil)
@@ -186,7 +190,7 @@ func GetServicePrincipalToken(tenantId string, env *azure.Environment, resource 
 	}
 	// When flexvolume driver is using a Service Principal clientid + client secret to retrieve token for resource
 	if len(aADClientSecret) > 0 {
-		glog.V(2).Infoln("azure: using client_id+client_secret to retrieve access token")
+		glog.V(2).Infof("azure: using client_id+client_secret to retrieve access token for %s/%s", podns, podname)
 		return adal.NewServicePrincipalToken(
 			*oauthConfig,
 			aADClientID,


### PR DESCRIPTION
<!-- Thank you for helping Key Vault FlexVol with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in Key Vault FlexVol? Why is it needed? -->
- Fixes error check when getting management token. The error that's used in `errors.Wrap` is always nil because it's the wrong var.
- Fix lint errors

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes https://github.com/Azure/kubernetes-keyvault-flexvol/issues/115

**Notes for Reviewers**:
When the error is nil in `errors.Wrap` the final out of `errors.Wrap` is nil. This issue existed in `v0.0.10` as well, but was caught in the next step failing to get token to initialize the kv client. In `v0.0.11` this became more evident as we also check if the vault url is not nil. So by wrapping the nil error and returning from `getVaultURL()` the err is nil (when it's not) and the vault url is nil because there was an error. Since that check was again wrapping an error which was nil, kubelet gets nil error and assumes a success.