### PR TITLE
Change updateStrategy to RollingUpdate for keyvault-flexvolume

### DIFF
--- a/deployment/kv-flexvol-installer.yaml
+++ b/deployment/kv-flexvol-installer.yaml
@@ -11,6 +11,8 @@ metadata:
   name: keyvault-flexvolume
   namespace: kv
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
<!-- Thank you for helping Key Vault FlexVol with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in Key Vault FlexVol? Why is it needed? -->
The default update strategy is `OnDelete` for `extensions/v1beta1`. So setting it to `RollingUpdate` explicitly. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
