### PR TITLE
Support system assigned and user assigned managed identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ Fill in the missing pieces in [this](https://github.com/Azure/kubernetes-keyvaul
 
     |Name|Required|Description|Default Value|
     |---|---|---|---|
-    |usepodidentity|no|specify access mode: service principal or pod identity or azure managed identity|"false"|
-    |usemanagedidentity|no|specify access mode: use service principal or pod identity or azure managed identity|"false"|
-    |managedidentityclientid|no|specify the azure managed identity client id to use. specify empty to use the system assigned identity on VMSS|""|
+    |usepodidentity|no|specify access mode: use a service principal or pod identity or vm managed identity|"false"|
+    |usevmmanagedidentity|no|specify access mode: use a service principal or pod identity or vm managed identity|"false"|
+    |vmmanagedidentityclientid|no|If using a user assigned identity as the VM's managed identity, then specify the identity's client id. If empty, then defaults to use the system assigned identity on the VM|""|
     |keyvaultname|yes|name of Key Vault instance|""|
     |keyvaultobjectnames|yes|names of Key Vault objects to access|""|
     |keyvaultobjectaliases|no|filenames to use when writing the objects|keyvaultobjectnames|
@@ -140,8 +140,8 @@ Fill in the missing pieces in [this](https://github.com/Azure/kubernetes-keyvaul
             name: kvcreds                             # [OPTIONAL] not required if using Pod Identity
           options:
             usepodidentity: "false"                   # [OPTIONAL] if not provided, will default to "false"
-            usemanagedidentity: "false"               # [OPTIONAL] if not provided, will default to "false"
-            managedidentityclientid: "clientid"       # [OPTIONAL] use the client id to specify which user assigned managed identity to use, leave empty to use system assigned managed identity
+            usevmmanagedidentity: "false"             # [OPTIONAL] if not provided, will default to "false"
+            vmmanagedidentityclientid: "clientid"     # [OPTIONAL] use the client id to specify which user assigned managed identity to use, leave empty to use system assigned managed identity
             keyvaultname: "testkeyvault"              # [REQUIRED] the name of the KeyVault
             keyvaultobjectnames: "testsecret"         # [REQUIRED] list of KeyVault object names (semi-colon separated)
             keyvaultobjectaliases: "secret.json"      # [OPTIONAL] list of KeyVault object aliases
@@ -287,9 +287,9 @@ Fill in the missing pieces in [this](https://github.com/Azure/kubernetes-keyvaul
 
   > **NOTE**: When using the `Pod Identity` option mode, there may be some delay in obtaining the objects from Key Vault. During pod creation time, AAD Pod Identity needs to create the `AzureAssignedIdentity` for the pod based on the `AzureIdentity` and `AzureIdentityBinding` and retrieve the token for Key Vault. It is possible for the pod volume mount to fail during this time. If it does, the kubelet will keep retrying until after the token retrieval is complete and the mount succeeds.
 
-#### OPTION 3: VMSS Managed Identity
+#### OPTION 3: VMSS User Assigned Managed Identity
 
-This option allows flexvol to use the managed identity assigned on the k8s cluster VMSS directly.
+This option allows flexvol to use the user assigned managed identity on the k8s cluster VMSS directly.
 
 > Warning: As of today (2019/09), AKS does not preserve the user assigned identity on VMSS during upgrade. You will need re-assign the managed identities to VMSS after an upgrade. The improved experience is planned.
 
@@ -318,10 +318,10 @@ az identity create -g <RESOURCE GROUP> -n <IDENTITY NAME>
 az vmss identity assign -g <RESOURCE GROUP> -n <K8S-AGENT-POOL-VMSS> --identities <USER ASSIGNED IDENTITY>
 ```
 
-4. Deploy your application. Specify `usemanagedidentity` to `true`.
+4. Deploy your application. Specify `usevmmanagedidentity` to `true`.
 ```yaml
-usemanagedidentity: "true"               # [OPTIONAL] if not provided, will default to "false"
-managedidentityclientid: "clientid"       # [OPTIONAL] use the client id to specify which user assigned managed identity to use, leave empty to use system assigned managed identity
+usevmmanagedidentity: "true"               # [OPTIONAL] if not provided, will default to "false"
+vmmanagedidentityclientid: "clientid"      # [OPTIONAL] use the client id to specify which user assigned managed identity to use, leave empty to use system assigned managed identity
 ```
 
 ## Detailed use cases

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Fill in the missing pieces in [this](https://github.com/Azure/kubernetes-keyvaul
 
 This option allows flexvol to use the managed identity assigned on the k8s cluster VMSS directly.
 
-> Warning: AKS as of today (2019/09) does not preserve the user assigned identity on VMSS during upgrade. You will need re-attach the managed identities to VMSS after an upgrade.
+> Warning: As of today (2019/09), AKS does not preserve the user assigned identity on VMSS during upgrade. You will need re-assign the managed identities to VMSS after an upgrade. The improved experience is planned.
 
 1. Create Azure Managed Identity
 

--- a/azurekeyvault-flexvolume/AUTHORS
+++ b/azurekeyvault-flexvolume/AUTHORS
@@ -1,8 +1,16 @@
+Anish Ramasekar <rita.z.zhang@gmail.com>
+Bhargav Nookala <rita.z.zhang@gmail.com>
+Dan Billeci <dbilleci@danno62-2.lan>
 Idan <rita.z.zhang@gmail.com>
 Jacob Sohl <jacobsohl@gmail.com>
+Jason Hansen <rita.z.zhang@gmail.com>
+Jon Walton <rita.z.zhang@gmail.com>
 Khaled Henidak(Kal) <khnidk@microsoft.com>
+Matt Boersma <rita.z.zhang@gmail.com>
 Paulo Gomes <Paulo.Gomes.uk@gmail.com>
 Rita Zhang <rita.z.zhang@gmail.com>
+Stéphane Erbrech <rita.z.zhang@gmail.com>
 Stéphane Erbrech <stephane.erbrech@gmail.com>
 Stephane Erbrech <sterbrec@microsoft.com>
+Tim Jacomb <rita.z.zhang@gmail.com>
 twem <rita.z.zhang@gmail.com>

--- a/azurekeyvault-flexvolume/AUTHORS
+++ b/azurekeyvault-flexvolume/AUTHORS
@@ -1,16 +1,8 @@
-Anish Ramasekar <rita.z.zhang@gmail.com>
-Bhargav Nookala <rita.z.zhang@gmail.com>
-Dan Billeci <dbilleci@danno62-2.lan>
 Idan <rita.z.zhang@gmail.com>
 Jacob Sohl <jacobsohl@gmail.com>
-Jason Hansen <rita.z.zhang@gmail.com>
-Jon Walton <rita.z.zhang@gmail.com>
 Khaled Henidak(Kal) <khnidk@microsoft.com>
-Matt Boersma <rita.z.zhang@gmail.com>
 Paulo Gomes <Paulo.Gomes.uk@gmail.com>
 Rita Zhang <rita.z.zhang@gmail.com>
-Stéphane Erbrech <rita.z.zhang@gmail.com>
 Stéphane Erbrech <stephane.erbrech@gmail.com>
 Stephane Erbrech <sterbrec@microsoft.com>
-Tim Jacomb <rita.z.zhang@gmail.com>
 twem <rita.z.zhang@gmail.com>

--- a/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
+++ b/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
@@ -112,7 +112,7 @@ func (adapter *KeyvaultFlexvolumeAdapter) initializeKvClient() (*kv.BaseClient, 
 	kvClient := kv.New()
 	options := adapter.options
 
-	token, err := GetKeyvaultToken(AuthGrantType(), options.cloudName, options.tenantID, options.usePodIdentity, options.aADClientSecret, options.aADClientID, options.podName, options.podNamespace)
+	token, err := GetKeyvaultToken(AuthGrantType(), options.cloudName, options.tenantID, options.usePodIdentity, options.useManagedIdentity, options.managedIdentityClientID, options.aADClientSecret, options.aADClientID, options.podName, options.podNamespace)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get key vault token")
 	}

--- a/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
+++ b/azurekeyvault-flexvolume/keyvaultFlexvolumeAdapter.go
@@ -112,7 +112,7 @@ func (adapter *KeyvaultFlexvolumeAdapter) initializeKvClient() (*kv.BaseClient, 
 	kvClient := kv.New()
 	options := adapter.options
 
-	token, err := GetKeyvaultToken(AuthGrantType(), options.cloudName, options.tenantID, options.usePodIdentity, options.useManagedIdentity, options.managedIdentityClientID, options.aADClientSecret, options.aADClientID, options.podName, options.podNamespace)
+	token, err := GetKeyvaultToken(AuthGrantType(), options.cloudName, options.tenantID, options.usePodIdentity, options.useVmManagedIdentity, options.vmManagedIdentityClientID, options.aADClientSecret, options.aADClientID, options.podName, options.podNamespace)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get key vault token")
 	}

--- a/azurekeyvault-flexvolume/main.go
+++ b/azurekeyvault-flexvolume/main.go
@@ -55,9 +55,9 @@ type Option struct {
 	// POD AAD Identity flag
 	usePodIdentity bool
 	// VM managed identity flag
-	useManagedIdentity bool
+	useVmManagedIdentity bool
 	// the managed identity client ID
-	managedIdentityClientID string
+	vmManagedIdentityClientID string
 	// AAD app client secret (if not using POD AAD Identity)
 	aADClientSecret string
 	// AAD app client secret id (if not using POD AAD Identity)
@@ -97,8 +97,8 @@ func parseConfigs() (*Option, error) {
 	flag.StringVar(&options.cloudName, "cloudName", "", "Type of Azure cloud")
 	flag.StringVar(&options.tenantID, "tenantId", "", "tenantId to Azure")
 	flag.BoolVar(&options.usePodIdentity, "usePodIdentity", false, "usePodIdentity for using pod identity.")
-	flag.BoolVar(&options.useManagedIdentity, "useManagedIdentity", false, "Use the VM managed identity.")
-	flag.StringVar(&options.managedIdentityClientID, "managedIdentityClientID", "", "The managed identity client ID. Empty to use the System Assigned identity.")
+	flag.BoolVar(&options.useVmManagedIdentity, "useVmManagedIdentity", false, "Use the VM managed identity.")
+	flag.StringVar(&options.vmManagedIdentityClientID, "vmManagedIdentityClientID", "", "The VM managed identity client ID. Empty to use the System Assigned identity.")
 	flag.StringVar(&options.dir, "dir", "", "Directory path to write data.")
 	flag.BoolVar(&options.showVersion, "version", true, "Show version.")
 	flag.StringVar(&options.podName, "podName", "", "Name of the pod")
@@ -138,14 +138,16 @@ func Validate(options Option) error {
 		return fmt.Errorf("-vaultObjectNames and -vaultObjectAliases do not have the same number of items")
 	}
 
-	if !options.usePodIdentity && !options.useManagedIdentity {
+	if !options.usePodIdentity && !options.useVmManagedIdentity {
 		if options.aADClientID == "" {
 			return fmt.Errorf("-aADClientID is not set")
 		}
 		if options.aADClientSecret == "" {
 			return fmt.Errorf("-aADClientSecret is not set")
 		}
-	} else if !options.useManagedIdentity {
+	}
+
+	if options.usePodIdentity {
 		if options.podName == "" {
 			return fmt.Errorf("-podName is not set")
 		}

--- a/azurekeyvault-flexvolume/oauth.go
+++ b/azurekeyvault-flexvolume/oauth.go
@@ -84,7 +84,7 @@ type NMIResponse struct {
 }
 
 // GetKeyvaultToken retrieves a new service principal token to access keyvault
-func GetKeyvaultToken(grantType OAuthGrantType, cloudName, tenantID string, usePodIdentity bool, aADClientSecret, aADClientID, podname, podns string) (authorizer autorest.Authorizer, err error) {
+func GetKeyvaultToken(grantType OAuthGrantType, cloudName, tenantID string, usePodIdentity, useManagedIdentity bool, managedIdentityClientID, aADClientSecret, aADClientID, podname, podns string) (authorizer autorest.Authorizer, err error) {
 	err = adal.AddToUserAgent(GetUserAgent())
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to add user agent to adal")
@@ -98,7 +98,7 @@ func GetKeyvaultToken(grantType OAuthGrantType, cloudName, tenantID string, useP
 	if '/' == kvEndPoint[len(kvEndPoint)-1] {
 		kvEndPoint = kvEndPoint[:len(kvEndPoint)-1]
 	}
-	servicePrincipalToken, err := GetServicePrincipalToken(tenantID, env, kvEndPoint, usePodIdentity, aADClientSecret, aADClientID, podname, podns)
+	servicePrincipalToken, err := GetServicePrincipalToken(tenantID, env, kvEndPoint, usePodIdentity, useManagedIdentity, managedIdentityClientID, aADClientSecret, aADClientID, podname, podns)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get service principal token")
 	}
@@ -108,7 +108,7 @@ func GetKeyvaultToken(grantType OAuthGrantType, cloudName, tenantID string, useP
 }
 
 // GetServicePrincipalToken creates a new service principal token based on the configuration
-func GetServicePrincipalToken(tenantID string, env *azure.Environment, resource string, usePodIdentity bool, aADClientSecret, aADClientID, podname, podns string) (*adal.ServicePrincipalToken, error) {
+func GetServicePrincipalToken(tenantID string, env *azure.Environment, resource string, usePodIdentity bool, useManagedIdentity bool, managedIdentityClientID, aADClientSecret, aADClientID, podname, podns string) (*adal.ServicePrincipalToken, error) {
 	oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, tenantID)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed creating the OAuth config")
@@ -169,6 +169,27 @@ func GetServicePrincipalToken(tenantID string, env *azure.Environment, resource 
 
 		return nil, fmt.Errorf("nmi response failed with status code: %d", resp.StatusCode)
 	}
+
+	if useManagedIdentity {
+		msiEndpoint, err := adal.GetMSIVMEndpoint()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get managed identity (MSI) endpoint")
+		}
+
+		if managedIdentityClientID != "" {
+			glog.V(2).Infof("azure: using user assigned managed identity %s to retrieve access token for %s/%s", managedIdentityClientID, podns, podname)
+			return adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(
+				msiEndpoint,
+				resource,
+				managedIdentityClientID)
+		}
+
+		glog.V(2).Infof("azure: using system assigned managed identity to retrieve access token for %s/%s", podns, podname)
+		return adal.NewServicePrincipalTokenFromMSI(
+			msiEndpoint,
+			resource)
+	}
+
 	// When flexvolume driver is using a Service Principal clientid + client secret to retrieve token for resource
 	if len(aADClientSecret) > 0 {
 		glog.V(2).Infof("azure: using client_id+client_secret to retrieve access token for %s/%s", podns, podname)

--- a/deployment/flexvol-installer/kv
+++ b/deployment/flexvol-installer/kv
@@ -52,7 +52,7 @@ mount() {
 	
 	USE_POD_IDENTITY="$(echo "$2"|"$JQ" -r '.usepodidentity //empty')"
 	USE_MANAGED_IDENTITY="$(echo "$2"|"$JQ" -r '.usemanagedidentity //empty')"
-	MANAGED_IDENTITY_ID="$(echo "$2"|"$JQ" -r '.managedidentityid //empty')"
+	MANAGED_IDENTITY_CLIENT_ID="$(echo "$2"|"$JQ" -r '.managedidentityclientid //empty')"
 
 	# Optional
 	CLOUD_NAME="$(echo "$2"|"$JQ" -r '.cloudname //empty')"

--- a/deployment/flexvol-installer/kv
+++ b/deployment/flexvol-installer/kv
@@ -51,6 +51,8 @@ mount() {
 	KEYVAULT_OBJECT_TYPES="$(echo "$2"|"$JQ" -r '.keyvaultobjecttypes //empty')"
 	
 	USE_POD_IDENTITY="$(echo "$2"|"$JQ" -r '.usepodidentity //empty')"
+	USE_MANAGED_IDENTITY="$(echo "$2"|"$JQ" -r '.usemanagedidentity //empty')"
+	MANAGED_IDENTITY_ID="$(echo "$2"|"$JQ" -r '.managedidentityid //empty')"
 
 	# Optional
 	CLOUD_NAME="$(echo "$2"|"$JQ" -r '.cloudname //empty')"

--- a/deployment/flexvol-installer/kv
+++ b/deployment/flexvol-installer/kv
@@ -96,7 +96,15 @@ mount() {
 		USE_POD_IDENTITY=false
 	fi
 
-	if [ "${USE_POD_IDENTITY}" = false ]; then
+	if [ -z "${USE_MANAGED_IDENTITY}" ]; then
+		USE_MANAGED_IDENTITY=false
+	fi
+
+	if [ -z "${MANAGED_IDENTITY_ID}" ]; then
+		MANAGED_IDENTITY_ID=""
+	fi 
+
+	if [ "${USE_POD_IDENTITY}" = false -a "${USE_MANAGED_IDENTITY}" = false ]; then
 		if [ -z "${CLIENTID}" ]; then
 			err "{\"status\": \"Failure\", \"message\": \"validation failed, secret/clientid is empty\"}"
 			exit 1
@@ -108,7 +116,7 @@ mount() {
 		fi
 
 		echo "`date` CLIENTID: ${CLIENTID}" >> $LOG
-	else
+	elif [ "${USE_POD_IDENTITY}" = true ]; then
 		if [ -z "${PODNAMESPACE}" ]; then
 			err "{\"status\": \"Failure\", \"message\": \"validation failed, pod.namespace is empty\"}"
 			exit 1
@@ -143,7 +151,7 @@ mount() {
 	fi
 
 	echo "`date` $KVFV -logtostderr=1 -vaultName=${KEYVAULT_NAME} -vaultObjectNames=${KEYVAULT_OBJECT_NAMES} -vaultObjectAliases=${KEYVAULT_OBJECT_ALIASES} -dir=${MNTPATH} -cloudName=${CLOUD_NAME} -tenantId=${TENANT_ID} -aADClientSecret=**** -aADClientID=${CLIENTID} -usePodIdentity=${USE_POD_IDENTITY} -podNamespace=${PODNAMESPACE} -podName=${PODNAME} -vaultObjectVersions=${KEYVAULT_OBJECT_VERSIONS} -vaultObjectTypes=${KEYVAULT_OBJECT_TYPES}" >> $LOG
-	$KVFV -logtostderr=1 -vaultName=${KEYVAULT_NAME} -vaultObjectNames=${KEYVAULT_OBJECT_NAMES} -vaultObjectAliases=${KEYVAULT_OBJECT_ALIASES} -dir=${MNTPATH} -cloudName=${CLOUD_NAME} -tenantId=${TENANT_ID} -aADClientSecret=${CLIENTSECRET} -aADClientID=${CLIENTID} -usePodIdentity=${USE_POD_IDENTITY} -podNamespace=${PODNAMESPACE} -podName=${PODNAME} -vaultObjectVersions=${KEYVAULT_OBJECT_VERSIONS} -vaultObjectTypes=${KEYVAULT_OBJECT_TYPES} >> $LOG 2>&1
+	$KVFV -logtostderr=1 -vaultName=${KEYVAULT_NAME} -vaultObjectNames=${KEYVAULT_OBJECT_NAMES} -vaultObjectAliases=${KEYVAULT_OBJECT_ALIASES} -dir=${MNTPATH} -cloudName=${CLOUD_NAME} -tenantId=${TENANT_ID} -aADClientSecret=${CLIENTSECRET} -aADClientID=${CLIENTID} -useManagedIdentity=${USE_MANAGED_IDENTITY} -managedIdentityClientID=${MANAGED_IDENTITY_CLIENT_ID} -usePodIdentity=${USE_POD_IDENTITY} -podNamespace=${PODNAMESPACE} -podName=${PODNAME} -vaultObjectVersions=${KEYVAULT_OBJECT_VERSIONS} -vaultObjectTypes=${KEYVAULT_OBJECT_TYPES} >> $LOG 2>&1
 	
 	if [ $? -ne 0 ] ; then
 		errorLog=`tail -n 1 "${LOG}" | sed 's/.*Message=//' | tr -d '"'`

--- a/deployment/flexvol-installer/kv
+++ b/deployment/flexvol-installer/kv
@@ -51,8 +51,8 @@ mount() {
 	KEYVAULT_OBJECT_TYPES="$(echo "$2"|"$JQ" -r '.keyvaultobjecttypes //empty')"
 	
 	USE_POD_IDENTITY="$(echo "$2"|"$JQ" -r '.usepodidentity //empty')"
-	USE_MANAGED_IDENTITY="$(echo "$2"|"$JQ" -r '.usemanagedidentity //empty')"
-	MANAGED_IDENTITY_CLIENT_ID="$(echo "$2"|"$JQ" -r '.managedidentityclientid //empty')"
+	USE_VM_MANAGED_IDENTITY="$(echo "$2"|"$JQ" -r '.usevmmanagedidentity //empty')"
+	VM_MANAGED_IDENTITY_CLIENT_ID="$(echo "$2"|"$JQ" -r '.vmmanagedidentityclientid //empty')"
 
 	# Optional
 	CLOUD_NAME="$(echo "$2"|"$JQ" -r '.cloudname //empty')"
@@ -98,15 +98,15 @@ mount() {
 		USE_POD_IDENTITY=false
 	fi
 
-	if [ -z "${USE_MANAGED_IDENTITY}" ]; then
-		USE_MANAGED_IDENTITY=false
+	if [ -z "${USE_VM_MANAGED_IDENTITY}" ]; then
+		USE_VM_MANAGED_IDENTITY=false
 	fi
 
-	if [ -z "${MANAGED_IDENTITY_ID}" ]; then
-		MANAGED_IDENTITY_ID=""
+	if [ -z "${VM_MANAGED_IDENTITY_CLIENT_ID}" ]; then
+		VM_MANAGED_IDENTITY_CLIENT_ID=""
 	fi 
 
-	if [ "${USE_POD_IDENTITY}" = false -a "${USE_MANAGED_IDENTITY}" = false ]; then
+	if [ "${USE_POD_IDENTITY}" = false -a "${USE_VM_MANAGED_IDENTITY}" = false ]; then
 		if [ -z "${CLIENTID}" ]; then
 			err "{\"status\": \"Failure\", \"message\": \"validation failed, secret/clientid is empty\"}"
 			exit 1
@@ -153,7 +153,7 @@ mount() {
 	fi
 
 	echo "`date` $KVFV -logtostderr=1 -vaultName=${KEYVAULT_NAME} -vaultObjectNames=${KEYVAULT_OBJECT_NAMES} -vaultObjectAliases=${KEYVAULT_OBJECT_ALIASES} -dir=${MNTPATH} -cloudName=${CLOUD_NAME} -tenantId=${TENANT_ID} -aADClientSecret=**** -aADClientID=${CLIENTID} -usePodIdentity=${USE_POD_IDENTITY} -podNamespace=${PODNAMESPACE} -podName=${PODNAME} -vaultObjectVersions=${KEYVAULT_OBJECT_VERSIONS} -vaultObjectTypes=${KEYVAULT_OBJECT_TYPES}" >> $LOG
-	$KVFV -logtostderr=1 -vaultName=${KEYVAULT_NAME} -vaultObjectNames=${KEYVAULT_OBJECT_NAMES} -vaultObjectAliases=${KEYVAULT_OBJECT_ALIASES} -dir=${MNTPATH} -cloudName=${CLOUD_NAME} -tenantId=${TENANT_ID} -aADClientSecret=${CLIENTSECRET} -aADClientID=${CLIENTID} -useManagedIdentity=${USE_MANAGED_IDENTITY} -managedIdentityClientID=${MANAGED_IDENTITY_CLIENT_ID} -usePodIdentity=${USE_POD_IDENTITY} -podNamespace=${PODNAMESPACE} -podName=${PODNAME} -vaultObjectVersions=${KEYVAULT_OBJECT_VERSIONS} -vaultObjectTypes=${KEYVAULT_OBJECT_TYPES} >> $LOG 2>&1
+	$KVFV -logtostderr=1 -vaultName=${KEYVAULT_NAME} -vaultObjectNames=${KEYVAULT_OBJECT_NAMES} -vaultObjectAliases=${KEYVAULT_OBJECT_ALIASES} -dir=${MNTPATH} -cloudName=${CLOUD_NAME} -tenantId=${TENANT_ID} -aADClientSecret=${CLIENTSECRET} -aADClientID=${CLIENTID} -useVmManagedIdentity=${USE_VM_MANAGED_IDENTITY} -vmManagedIdentityClientID=${VM_MANAGED_IDENTITY_CLIENT_ID} -usePodIdentity=${USE_POD_IDENTITY} -podNamespace=${PODNAMESPACE} -podName=${PODNAME} -vaultObjectVersions=${KEYVAULT_OBJECT_VERSIONS} -vaultObjectTypes=${KEYVAULT_OBJECT_TYPES} >> $LOG 2>&1
 	
 	if [ $? -ne 0 ] ; then
 		errorLog=`tail -n 1 "${LOG}" | sed 's/.*Message=//' | tr -d '"'`

--- a/deployment/nginx-flex-kv-managedidentity.yaml
+++ b/deployment/nginx-flex-kv-managedidentity.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: nginx-flex-kv-podid
+    aadpodidbinding: "NAME OF the AzureIdentityBinding SELECTOR"
+  name: nginx-flex-kv-podid
+spec:
+  containers:
+  - name: nginx-flex-kv-podid
+    image: nginx
+    volumeMounts:
+    - name: test
+      mountPath: /kvmnt
+      readOnly: true
+  volumes:
+  - name: test
+    flexVolume:
+      driver: "azure/kv"
+      options:
+        usemanagedidentity: "true"     # [OPTIONAL] if not provided, will default to "false"
+        keyvaultname: ""               # the name of the KeyVault
+        keyvaultobjectnames: ""        # list of KeyVault object names (semi-colon separated)
+        keyvaultobjecttypes: secret    # list of KeyVault object types: secret, key or cert (semi-colon separated)
+        keyvaultobjectversions: ""     # [OPTIONAL] list of KeyVault object versions (semi-colon separated), will get latest if empty
+        resourcegroup: ""              # [REQUIRED FOR < v0.0.14] the resource group of the KeyVault
+        subscriptionid: ""             # [REQUIRED FOR < v0.0.14] the subscription ID of the KeyVault
+        tenantid: ""                   # the tenant ID of the KeyVault

--- a/deployment/nginx-flex-kv-managedidentity.yaml
+++ b/deployment/nginx-flex-kv-managedidentity.yaml
@@ -2,12 +2,11 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    app: nginx-flex-kv-podid
-    aadpodidbinding: "NAME OF the AzureIdentityBinding SELECTOR"
-  name: nginx-flex-kv-podid
+    app: nginx-flex-kv
+  name: nginx-flex-kv
 spec:
   containers:
-  - name: nginx-flex-kv-podid
+  - name: nginx-flex-kv
     image: nginx
     volumeMounts:
     - name: test
@@ -18,11 +17,9 @@ spec:
     flexVolume:
       driver: "azure/kv"
       options:
-        usemanagedidentity: "true"     # [OPTIONAL] if not provided, will default to "false"
+        usevmmanagedidentity: "true"   # [OPTIONAL] if not provided, will default to "false"
         keyvaultname: ""               # the name of the KeyVault
         keyvaultobjectnames: ""        # list of KeyVault object names (semi-colon separated)
         keyvaultobjecttypes: secret    # list of KeyVault object types: secret, key or cert (semi-colon separated)
         keyvaultobjectversions: ""     # [OPTIONAL] list of KeyVault object versions (semi-colon separated), will get latest if empty
-        resourcegroup: ""              # [REQUIRED FOR < v0.0.14] the resource group of the KeyVault
-        subscriptionid: ""             # [REQUIRED FOR < v0.0.14] the subscription ID of the KeyVault
         tenantid: ""                   # the tenant ID of the KeyVault


### PR DESCRIPTION
<!-- Thank you for helping Key Vault FlexVol with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in Key Vault FlexVol? Why is it needed? -->
Allow FlexVol to use system assigned or user assigned managed identity on VM / VMSS directly without dependency on pod identity. This is preferred in some cases that we want less dependency, especially on a large scale cluster.

Tested on an AKS cluster without aad-pod-identity.

To use managed identity directly, the volume spec will specify:

```yaml
usevmmanagedidentity: "true"                 # [OPTIONAL] if not provided, will default to "false"
vmmanagedidentityclientid: "clientid"       # [OPTIONAL] use the client id to specify which user assigned managed identity to use, leave empty to use system assigned managed identity
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
