### PR TITLE
Update istio-tls-certificate.md

### DIFF
--- a/docs/istio-tls-certificate.md
+++ b/docs/istio-tls-certificate.md
@@ -64,7 +64,7 @@ We also add an extra volume that is referred to by the volume mount above:
         flexVolume:
           driver: "azure/kv"
           secretRef:
-            kvcreds
+            name: kvcreds
           options:
             usepodidentity: "false"
             keyvaultname: "mykeyvault"


### PR DESCRIPTION
Updating because without the name property it will error out with " error validating data: ValidationError(Deployment.spec.template.spec.volumes[0].flexVolume.secretRef): invalid type for io.k8s.api.core.v1.LocalObjectReference: got "array", expected "map""

**Reason for Change**:
Just a docs update so if folks copy and paste the yaml they don't run into an error message.

**Issue Fixed**:
Can open an issue if wanted, but figured it was a simple change.

**Notes for Reviewers**:
