### PR TITLE
Updated flexvol install dockerfile to alpine 3.11

### DIFF
--- a/deployment/flexvol-installer/Dockerfile
+++ b/deployment/flexvol-installer/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.11
 
 WORKDIR /bin
 


### PR DESCRIPTION
<!-- Thank you for helping Key Vault FlexVol with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in Key Vault FlexVol? Why is it needed? -->
Updates dockerfile in the flexvol-installer to a base image of alpine 3.11.  This addresses known CVE's in the base layer.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Bug 163
