### PR TITLE
Update kb-flexvol-installer for api changes in 1.17.0

### DIFF
--- a/deployment/kv-flexvol-installer.yaml
+++ b/deployment/kv-flexvol-installer.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: kv
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
@@ -11,6 +11,9 @@ metadata:
   name: keyvault-flexvolume
   namespace: kv
 spec:
+  selector:
+    matchLabels:
+      app: keyvault-flexvolume
   updateStrategy:
     type: RollingUpdate
   template:


### PR DESCRIPTION
**Reason for Change**:
Adds support for 1.17.0 .

**Issue Fixed**:
Fixes #168 

**Notes for Reviewers**:
* apiVersion - it's out of beta!
* spec now requires a selector
