### PR TITLE
Fixes missing jq on gke nodes issue #183

### DIFF
--- a/deployment/flexvol-installer/Dockerfile
+++ b/deployment/flexvol-installer/Dockerfile
@@ -5,8 +5,10 @@ WORKDIR /bin
 RUN apk add --no-cache bash
 ADD ./kv /bin/kv
 ADD ./azurekeyvault-flexvolume /bin/azurekeyvault-flexvolume
+ADD ./jq-replacement.py /bin/jq-replacement.py
 RUN chmod a+x /bin/kv
 RUN chmod a+x /bin/azurekeyvault-flexvolume
+RUN chmod a+x /bin/jq-replacement.py
 ADD ./install.sh /bin/install_kv_flexvol.sh
 
 

--- a/deployment/flexvol-installer/install.sh
+++ b/deployment/flexvol-installer/install.sh
@@ -15,6 +15,7 @@ mkdir -p ${kv_vol_dir}
 #copy
 cp /bin/kv ${kv_vol_dir}/kv
 cp /bin/azurekeyvault-flexvolume ${kv_vol_dir}/azurekeyvault-flexvolume #script
+cp /bin/jq-replacement.py ${kv_vol_dir}/jq-replacement.py
 
 
 #https://github.com/kubernetes/kubernetes/issues/17182

--- a/deployment/flexvol-installer/jq-replacement.py
+++ b/deployment/flexvol-installer/jq-replacement.py
@@ -1,0 +1,8 @@
+#!/usr/bin/python
+import sys
+import json
+
+data = json.load(sys.stdin)
+findkey = sys.argv[1]
+if findkey in data:
+    print(data[findkey])

--- a/deployment/flexvol-installer/kv
+++ b/deployment/flexvol-installer/kv
@@ -2,6 +2,7 @@
 
 DIR=$(dirname "$(readlink -f "$0")")
 JQ="/usr/bin/jq"
+PYTHON_JSON_PARSER="${DIR}/jq-replacement.py"
 LOG="/var/log/kv-driver.log"
 VER="0.0.16"
 KVFV="${DIR}/azurekeyvault-flexvolume"
@@ -37,8 +38,9 @@ ismounted() {
 
 mount() {
 	MNTPATH="$1"
-
-	CLIENTID="$(echo "$2"|"$JQ" -r '.["kubernetes.io/secret/clientid"] // empty' | base64 -d)"
+}
+jqparse() {
+    CLIENTID="$(echo "$2"|"$JQ" -r '.["kubernetes.io/secret/clientid"] // empty' | base64 -d)"
 	CLIENTSECRET="$(echo "$2"|"$JQ" -r '.["kubernetes.io/secret/clientsecret"] // empty' | tr -d '\n' | tr -d ' ' | base64 -d)"
 
 	PODNAMESPACE="$(echo "$2"|"$JQ" -r '.["kubernetes.io/pod.namespace"] // empty')"
@@ -66,6 +68,55 @@ mount() {
 		KEYVAULT_OBJECT_VERSIONS="$(echo "$2"|"$JQ" -r '.keyvaultobjectversion //empty')"
 
 	fi
+}
+
+pythonparse() {
+        EXAMPLE="$(echo "$2"|"$PYTHON_JSON_PARSER" 'tenantid')"
+        echo $EXAMPLE
+    CLIENTID="$(echo "$2"|"$PYTHON_JSON_PARSER" 'kubernetes.io/secret/clientid' | base64 -d)"
+	CLIENTSECRET="$(echo "$2"|"$PYTHON_JSON_PARSER" 'kubernetes.io/secret/clientsecret' | tr -d '\n' | tr -d ' ' | base64 -d)"
+
+	PODNAMESPACE="$(echo "$2"|"$PYTHON_JSON_PARSER" 'kubernetes.io/pod.namespace')"
+	PODNAME="$(echo "$2"|"$PYTHON_JSON_PARSER" 'kubernetes.io/pod.name')"
+
+	# Required
+	TENANT_ID="$(echo "$2"|"$PYTHON_JSON_PARSER" 'tenantid')"
+	KEYVAULT_NAME="$(echo "$2"|"$PYTHON_JSON_PARSER" 'keyvaultname')"
+	KEYVAULT_OBJECT_NAMES="$(echo "$2"|"$PYTHON_JSON_PARSER" 'keyvaultobjectnames')"
+	KEYVAULT_OBJECT_TYPES="$(echo "$2"|"$PYTHON_JSON_PARSER" 'keyvaultobjecttypes')"
+	
+	USE_POD_IDENTITY="$(echo "$2"|"$PYTHON_JSON_PARSER" 'usepodidentity')"
+	USE_VM_MANAGED_IDENTITY="$(echo "$2"|"$PYTHON_JSON_PARSER" 'usevmmanagedidentity')"
+	VM_MANAGED_IDENTITY_CLIENT_ID="$(echo "$2"|"$PYTHON_JSON_PARSER" 'vmmanagedidentityclientid')"
+
+	# Optional
+	CLOUD_NAME="$(echo "$2"|"$PYTHON_JSON_PARSER" 'cloudname')"
+	KEYVAULT_OBJECT_VERSIONS="$(echo "$2"|"$PYTHON_JSON_PARSER" 'keyvaultobjectversions')"
+	KEYVAULT_OBJECT_ALIASES="$(echo "$2"|"$PYTHON_JSON_PARSER" 'keyvaultobjectaliases')"
+	
+    # backward compatibility (should be deprecated!)
+	if [ -z "${KEYVAULT_OBJECT_NAMES}" ]; then
+		KEYVAULT_OBJECT_NAMES="$(echo "$2"|"$PYTHON_JSON_PARSER" 'keyvaultobjectname')"
+		KEYVAULT_OBJECT_TYPES="$(echo "$2"|"$PYTHON_JSON_PARSER" 'keyvaultobjecttype')"
+		KEYVAULT_OBJECT_VERSIONS="$(echo "$2"|"$PYTHON_JSON_PARSER" 'keyvaultobjectversion')"
+
+	fi
+}
+mount() {
+    MNTPATH="$1"
+
+    if JQEXISTS="$("$JQ" 2>&1)"; then
+            jqparse $*
+    else
+            if PYTHONEXISTS="$(python -c 'print(1)')"; then
+                    pythonparse $*
+            else
+                    log "{\"status\": \"Failure\", \"message\": \"could not parse json, node doesn't support jq nor python\"}"
+		            exit 1
+            fi
+    fi
+
+
 
 	if [ $(ismounted) -eq 1 ] ; then
 		log "{\"status\": \"Success\"}"


### PR DESCRIPTION
<!-- Thank you for helping Key Vault FlexVol with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in Key Vault FlexVol? Why is it needed? -->
GKE nodes (maybe others as well?) might not have `jq` installed and therefore will fail mounting the volume. See more at https://github.com/Azure/kubernetes-keyvault-flexvol/issues/183


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #183

**Notes for Reviewers**:

I have tested this solution on a GKE node. However, I haven't tested it on a node that does include `jq`. 

I am not sure if using python is the best way, but I assume that python exists on all *nix machines and would be the easiest solution for the time being. 